### PR TITLE
More metadata author consistency

### DIFF
--- a/examples/jpeg/metadata.yml
+++ b/examples/jpeg/metadata.yml
@@ -1,6 +1,6 @@
 title: JPEG
 description: A JPEG decoder demo.
-author: daft-freak
+author: daft_freak
 splash:
   file: ../no-image.png
 icon:

--- a/examples/mp3/metadata.yml
+++ b/examples/mp3/metadata.yml
@@ -1,6 +1,6 @@
 title: MP3 Test
 description: A basic MP3 audio test.
-author: daft-freak
+author: daft_freak
 splash:
   file: ../no-image.png
 icon:

--- a/examples/raycaster/metadata.yml
+++ b/examples/raycaster/metadata.yml
@@ -1,6 +1,6 @@
 title: Ray Caster
 description: Bug spray your way through abandoned ruins as the titular Ray Caster, international man of mistery.
-author: Pimoroni
+author: pimoroni
 splash:
   file: raycaster.png
 icon:

--- a/examples/text/metadata.yml
+++ b/examples/text/metadata.yml
@@ -1,6 +1,6 @@
 title: Text
 description: A demo of text placement and alignment.
-author: daft-freak
+author: daft_freak
 splash:
   file: ../no-image.png
 icon:

--- a/examples/tween-demo/metadata.yml
+++ b/examples/tween-demo/metadata.yml
@@ -1,6 +1,6 @@
 title: Tween Demo
 description: A simple demo of tween functions.
-author: daft-freak
+author: daft_freak
 splash:
   file: ../no-image.png
 icon:


### PR DESCRIPTION
Improves... this:
![Screenshot_2021-02-11 32blit Games](https://user-images.githubusercontent.com/3074891/107704575-61c34680-6cb5-11eb-9baa-ed9182862d5e.png)

Also changes the one example that uses "Pimoroni" instead of "pimoroni".
