### PR TITLE
Make most menu item lists const

### DIFF
--- a/32blit-stm32/Src/SystemMenu/about_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/about_menu.cpp
@@ -27,7 +27,7 @@ enum MenuItem {
   SD_CARD
 };
 
-static Menu::Item menu_items[]{
+static const Menu::Item menu_items[]{
   { FIRMWARE_VERSION, "Version" },
   { FIRMWARE_DATE, "Date" },
   { Menu::Separator, nullptr },

--- a/32blit-stm32/Src/SystemMenu/battery_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/battery_menu.cpp
@@ -25,7 +25,7 @@ enum MenuItem {
   VOLTAGE,
 };
 
-static Menu::Item menu_items[]{
+static const Menu::Item menu_items[]{
   {CHARGE, "Charge status"},
   {VBUS, "VBUS"},
   {VOLTAGE, "Voltage"},

--- a/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
@@ -29,7 +29,7 @@ enum MenuItem {
   STORAGE,
 };
 
-static Menu::Item menu_items[]{
+static const Menu::Item menu_items[]{
   {DFU, "DFU Mode"},
   {STORAGE, "Storage Mode"},
 };


### PR DESCRIPTION
Another patch I found in my giant pile of branches. Saves a little RAM.

(I have a another patch that makes all the USB descriptors const too https://github.com/Daft-Freak/32blit-beta/commit/b5494a36202c954ce55f4c6a3ff6e770d9b09455 which removes most of the firmware's `.data`)