### PR TITLE
Rework SDL scaling

### DIFF
--- a/32blit-sdl/Input.cpp
+++ b/32blit-sdl/Input.cpp
@@ -65,29 +65,25 @@ int Input::find_button(int button) {
 	else return iter->second;
 }
 
-Input::Input(SDL_Window *window, System *target) : target(target) {
-	int w, h;
-	SDL_GetWindowSize(window, &w, &h);
-	resize(w, h);
-}
-
-void Input::resize(int width, int height) {
-	win_width = width;
-	win_height = height;
+Input::Input(System *target) : target(target) {
 }
 
 bool Input::handle_mouse(int button, bool state, int x, int y) {
+
+  int half_w = target->mode() ? target->width / 2 : target->width / 4;
+  int half_h = target->mode() ? target->height / 2 : target->height / 4;
+
 	if (button == SDL_BUTTON_LEFT) {
 		if (state) {
 			if(left_ctrl){
-				_virtual_tilt(x, y);
+				_virtual_tilt(x, y, half_w, half_h);
 			} else {
-				x = x - (win_width / 2);
-				y = y - (win_height / 2);
-				_virtual_analog(x, y);
+				x = x - half_w;
+				y = y - half_h;
+				_virtual_analog(x, y, half_w, half_h);
 			}
 		} else {
-			_virtual_analog(0, 0);
+			_virtual_analog(0, 0, half_w, half_h);
 		}
 		return true;
 	}
@@ -134,10 +130,10 @@ bool Input::handle_controller_motion(int axis, int value) {
 	return false;
 }
 
-void Input::_virtual_tilt(int x, int y) {
+void Input::_virtual_tilt(int x, int y, int half_w, int half_h) {
 	float z = 80.0f;
-	x = x - (win_width / 2);
-	y = y - (win_height / 2);
+	x = x - half_w;
+	y = y - half_h;
 	blit::Vec3 shadow_tilt(x, y, z);
 	shadow_tilt.normalize();
 	target->set_tilt(0, shadow_tilt.x);
@@ -145,9 +141,9 @@ void Input::_virtual_tilt(int x, int y) {
 	target->set_tilt(2, shadow_tilt.z);
 }
 
-void Input::_virtual_analog(int x, int y) {
-	float jx = (float)x / (win_width / 2);
-	float jy = (float)y / (win_height / 2);
+void Input::_virtual_analog(int x, int y, int half_w, int half_h) {
+	float jx = (float)x / half_w;
+	float jy = (float)y / half_h;
 	target->set_joystick(0, jx);
 	target->set_joystick(1, jy);
 }

--- a/32blit-sdl/Input.hpp
+++ b/32blit-sdl/Input.hpp
@@ -9,9 +9,7 @@ class Input {
 		static int find_key(int key);
 		static int find_button(int button);
 
-		Input(SDL_Window *window, System *system);
-
-		void resize(int width, int height);
+		Input(System *system);
 
 		// Input handlers return true if they handled the event
 		bool handle_mouse(int button, bool state, int x, int y);
@@ -22,9 +20,8 @@ class Input {
 	private:
 		System *target;
 
-		void _virtual_analog(int, int);
-		void _virtual_tilt(int, int);
+		void _virtual_analog(int, int, int, int);
+		void _virtual_tilt(int, int, int, int);
 
-		int win_width, win_height;
 		bool left_ctrl = false;
 };

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -43,7 +43,6 @@ void handle_event(SDL_Event &event) {
 
 		case SDL_WINDOWEVENT:
 			if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
-				blit_input->resize(event.window.data1, event.window.data2);
 				blit_renderer->resize(event.window.data1, event.window.data2);
 			}
 			break;
@@ -189,7 +188,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	blit_system = new System();
-	blit_input = new Input(window, blit_system);
+	blit_input = new Input(blit_system);
 	blit_multiplayer = new Multiplayer(mp_mode, mp_address);
 	blit_renderer = new Renderer(window, System::width, System::height);
 	blit_audio = new Audio();

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -5,7 +5,7 @@ class Renderer {
 		Renderer(SDL_Window *window, int width, int height);
 		~Renderer();
 
-		enum Mode {Stretch, KeepAspect, KeepPixels, KeepPixelsLores};
+		enum Mode {Stretch, KeepAspect, KeepPixels};
 
 		void resize(int width, int height);
 		void update(System *sys);
@@ -19,9 +19,9 @@ class Renderer {
 		int sys_width, sys_height;
 		int win_width, win_height;
 
+    bool is_lores = false;
 		Mode mode = KeepPixels;
 		SDL_Renderer *renderer = nullptr;
-		SDL_Rect dest = {0, 0, 0, 0};
 
 		SDL_Texture *fb_lores_texture = nullptr;
 		SDL_Texture *fb_hires_texture = nullptr;


### PR DESCRIPTION
I realised that you can pretty easily get access to SDL events in a game with something like:
```c++
#ifndef TARGET_32BLIT_HW
#include <SDL.h>

int sdl_event_watch(void *user_data, SDL_Event *event) {
    switch(event->type) {
        //...
    }
    return 1;
}

#endif

void init() {
    //...

#ifndef TARGET_32BLIT_HW
    SDL_AddEventWatch(sdl_event_watch, nullptr);
#endif
}
```

So, I attempted to do something with the mouse... coords were all wrong due to the scaling. Then I realised that _almost_ all the scaling stuff could be replaced with `SDL_RenderSetLogicalSize`/`SDL_RenderSetIntegerScale`, which also scales input. (The `Stretch` mode is a bit nasty, I'm just overriding the scale every resize... but only the `KeepPixels` mode is actually used.)