### PR TITLE
Handle more files in the launcher without crashing

### DIFF
--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -189,7 +189,6 @@ void load_file_list(std::string directory) {
       BlitGameMetadata meta;
       if(parse_file_metadata(game.filename, meta)) {
         game.title = meta.title;
-        game.checksum = meta.crc32;
       }
 
       game_list.push_back(game);
@@ -218,7 +217,8 @@ void load_file_list(std::string directory) {
       game.type = GameType::file;
       game.title = file.name;
       game.filename = directory == "/" ? file.name : directory + "/" + file.name;
-      game.ext = ext;
+      strncpy(game.ext, ext.c_str(), 5);
+      game.ext[4] = 0;
       game.size = file.size;
       game.can_launch = true;
 
@@ -240,9 +240,9 @@ void load_current_game_metadata() {
   if(!game_list.empty()) {
     selected_game = game_list[selected_menu_item];
 
-    if(!selected_game.ext.empty()) {
+    if(selected_game.type == GameType::file) {
       // not a .blit
-      auto handler_meta = (char *)api.get_type_handler_metadata(selected_game.ext.c_str());
+      auto handler_meta = (char *)api.get_type_handler_metadata(selected_game.ext);
       auto len = *reinterpret_cast<uint16_t *>(handler_meta + 8);
 
       parse_metadata(handler_meta + 10, len, selected_game_metadata, true);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -156,7 +156,11 @@ void load_file_list(std::string directory) {
 
   game_list.clear();
 
-  for(auto &file : ::list_files(directory)) {
+  auto files = list_files(directory);
+
+  game_list.reserve(files.size()); // worst case
+
+  for(auto &file : files) {
     if(file.flags & blit::FileFlags::directory)
       continue;
 
@@ -229,6 +233,9 @@ void load_file_list(std::string directory) {
   int total_items = (int)game_list.size();
   if(selected_menu_item >= total_items)
     selected_menu_item = total_items - 1;
+
+  // probably doesn't do anything...
+  game_list.shrink_to_fit();
 
   sort_file_list();
 }

--- a/launcher/launcher.hpp
+++ b/launcher/launcher.hpp
@@ -17,7 +17,7 @@ enum class Screen {
   screenshot
 };
 
-enum class GameType {
+enum class GameType : uint8_t {
   game,
   file,
   screenshot
@@ -25,13 +25,13 @@ enum class GameType {
 
 struct GameInfo {
   GameType type;
+  bool can_launch = true; // use in future to flag games with an API mismatch
+  char ext[5]{0};
 
   std::string title;
-  uint32_t size, checksum = 0;
+  uint32_t size;
 
-  bool can_launch = true; // use in future to flag games with an API mismatch
-
-  std::string filename, ext;
+  std::string filename;
 };
 
 struct DirectoryInfo {

--- a/vs/launcher/launcher.vcxproj
+++ b/vs/launcher/launcher.vcxproj
@@ -84,7 +84,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\32blit;..\..\launcher-shared;..\..\vs\launcher;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -103,7 +103,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\32blit;..\..\launcher-shared;..\..\vs\launcher;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -124,7 +124,7 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\32blit;..\..\launcher-shared;..\..\vs\launcher;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -147,7 +147,7 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\32blit;..\..\launcher-shared;..\..\vs\launcher;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
Allows the launcher to list more associated files (tested to about 700-800), with the side effect that it will now crash on a larger directory even if the files aren't associated.

(Without pre-reserving the vector, the exponential growth causes it to run out of memory part way through the loop. Using https://github.com/Daft-Freak/32blit-beta/commit/6ae6dba6397d508d0586ae058f6756fa2f1b8ae7 to actually detect out of memory.)