### PR TITLE
Sprite scale example

### DIFF
--- a/examples/sprite-test/sprite-test.cpp
+++ b/examples/sprite-test/sprite-test.cpp
@@ -96,7 +96,9 @@ void render(uint32_t time_ms) {
   );
 
   // Also, stretched with the scale factor of the normal sprite functions
-  screen.sprite(Point(0,0), Point(130,40), Point(0,0), 2.0f);
+  // The second Point() argument here is the origin for any transform applied,
+  // but here we aren't applying one.
+  screen.sprite(0, Point(130, 40), Point(0, 0), 2.0f);
 
   uint32_t ms_end = now();
 

--- a/examples/sprite-test/sprite-test.cpp
+++ b/examples/sprite-test/sprite-test.cpp
@@ -39,7 +39,8 @@ void render(uint32_t time_ms) {
   screen.text("Flip", minimal_font, Point(5, 100));
 
   // Right Titles
-  screen.text("Big", minimal_font, Point(85, 20));
+  screen.text("Big\n(Blit)", minimal_font, Point(85, 20));
+  screen.text("Big\n(Sprite)", minimal_font, Point(85, 40));
 
   screen.pen = Pen(0, 0, 0);
   screen.text("Sprite demo", minimal_font, Point(5, 4));
@@ -93,6 +94,9 @@ void render(uint32_t time_ms) {
     Rect(0, 0, 8, 8),
     Rect(130, 16, 16, 16)
   );
+
+  // Also, stretched with the scale factor of the normal sprite functions
+  screen.sprite(Point(0,0), Point(130,40), Point(0,0), 2.0f);
 
   uint32_t ms_end = now();
 


### PR DESCRIPTION
Added a `screen.sprite` example using the scale options.