### PR TITLE
Multiplayer improvements

### DIFF
--- a/32blit-stm32/Inc/multiplayer.hpp
+++ b/32blit-stm32/Inc/multiplayer.hpp
@@ -8,4 +8,6 @@ namespace multiplayer {
   bool is_connected();
   void set_enabled(bool enabled);
   void send_message(const uint8_t *data, uint16_t length);
+
+  void update();
 }

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -63,7 +63,7 @@ const uint32_t long_press_exit_time = 1000;
 
 static uint32_t last_input_time = 0;
 static float sleep_fade = 1.0f;
-const int sleep_inactivity_time = 30000; // ms before sleeping
+const int sleep_inactivity_time = 120000; // ms before sleeping
 const int sleep_fade_out_time = 3000, sleep_fade_in_time = 500;
 
 __attribute__((section(".persist"))) Persist persist;
@@ -182,6 +182,8 @@ void blit_tick() {
   blit_process_input();
   blit_update_led();
   blit_update_vibration();
+
+  multiplayer::update();
 
   // SD card inserted/removed
   if(blit_sd_detected() != fs_mounted) {
@@ -619,7 +621,7 @@ void blit_process_input() {
     joystick_y = 0;
   }
   blit::joystick.y = -joystick_y / 7168.0f;
-  
+
   if(blit::joystick.length() > 0.01f)
     last_input_time = HAL_GetTick();
 

--- a/32blit-stm32/Src/SystemMenu/about_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/about_menu.cpp
@@ -27,7 +27,7 @@ enum MenuItem {
   SD_CARD
 };
 
-static Menu::Item menu_items[]{
+static const Menu::Item menu_items[]{
   { FIRMWARE_VERSION, "Version" },
   { FIRMWARE_DATE, "Date" },
   { Menu::Separator, nullptr },

--- a/32blit-stm32/Src/SystemMenu/battery_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/battery_menu.cpp
@@ -25,7 +25,7 @@ enum MenuItem {
   VOLTAGE,
 };
 
-static Menu::Item menu_items[]{
+static const Menu::Item menu_items[]{
   {CHARGE, "Charge status"},
   {VBUS, "VBUS"},
   {VOLTAGE, "Voltage"},

--- a/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
@@ -29,7 +29,7 @@ enum MenuItem {
   STORAGE,
 };
 
-static Menu::Item menu_items[]{
+static const Menu::Item menu_items[]{
   {DFU, "DFU Mode"},
   {STORAGE, "Storage Mode"},
 };

--- a/32blit-stm32/Src/multiplayer.cpp
+++ b/32blit-stm32/Src/multiplayer.cpp
@@ -165,6 +165,9 @@ namespace multiplayer {
   }
 
   void send_message(const uint8_t *data, uint16_t length) {
+    if(!peer_connected)
+      return;
+
     // header
     cdc_send((uint8_t *)"32BLUSER", 8);
     cdc_send((uint8_t *)&length, 2);


### PR DESCRIPTION
This allows SDL to receive messages faster than one every 20ms(#597) and adds a handshake to the STM32 backend so that `is_multiplayer_connected` actually means that two devices are connected and in "multiplayer mode" (#598).