### PR TITLE
No auto-launch on CDC flash

### DIFF
--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -44,7 +44,7 @@ function(blit_executable NAME SOURCES)
 		COMMAND ${PYTHON_EXECUTABLE} -m ttblit relocs --elf-file $<TARGET_FILE:${NAME}> --bin-file ${NAME}.bin --output ${BLIT_FILENAME}
 	)
 
-	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${PYTHON_EXECUTABLE} -m ttblit flash flash --port=${FLASH_PORT} --file=${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
+	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${PYTHON_EXECUTABLE} -m ttblit install --port=${FLASH_PORT} --launch ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
 endfunction()
 
 function(blit_metadata TARGET FILE)

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -900,6 +900,7 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
             } else if(m_uParseIndex == 1) {
               num_relocs = word;
               m_uFilelen -= num_relocs * 4 + 8;
+              relocation_offsets.clear();
               relocation_offsets.reserve(num_relocs);
             } else if(m_uParseIndex)
               relocation_offsets.push_back(word - qspi_flash_address);

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -1045,10 +1045,21 @@ void FlashLoader::handle_data_end(bool success) {
       meta.size = header.end - qspi_flash_address;
       if(parse_flash_metadata(flash_start_offset, meta)) {
         cleanup_duplicates(meta, flash_start_offset);
+
+        if(strcmp(meta.category, "launcher") == 0 || strcmp(meta.category, "firmware") == 0) {
+          // if we just flashed a launcher, we need to launch it now as we probably just erased the running one
+          blit_switch_execution(flash_start_offset, true);
+          return;
+        }
       }
 
-      // start it
-      blit_switch_execution(flash_start_offset, true);
+      scan_flash();
+
+      if(flash_mapped) {
+        qspi_enable_memorymapped_mode();
+        flash_mapped = false;
+      }
+      blit_enable_user_code();
     }
   }
 }


### PR DESCRIPTION
Removes the auto-launch after flashing something through CDC. However, if the flashed file is a launcher we still have to run it as we probably just deleted the running one... (Similar thing for firmware-updates)