### PR TITLE
Get metadata API

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -258,6 +258,8 @@ const char *metadata_title = \"${METADATA_TITLE}\";
 const char *metadata_author = \"${METADATA_AUTHOR}\";
 const char *metadata_description = \"${METADATA_DESCRIPTION}\";
 const char *metadata_version = \"${METADATA_VERSION}\";
+const char *metadata_url = \"${METADATA_URL}\";
+const char *metadata_category = \"${METADATA_CATEGORY}\";
 		"
 	)
 	target_sources(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/_metadata.cpp)

--- a/32blit-sdl/DefaultMetadata.cpp
+++ b/32blit-sdl/DefaultMetadata.cpp
@@ -10,3 +10,5 @@ WEAK const char *metadata_title = "32Blit Game";
 WEAK const char *metadata_author = "Unknown";
 WEAK const char *metadata_description = "";
 WEAK const char *metadata_version = "v0.0.0";
+WEAK const char *metadata_url = "";
+WEAK const char *metadata_category = "";

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -94,6 +94,19 @@ static const char *get_launch_path() {
   return nullptr; // TODO: argv[1]
 }
 
+static blit::GameMetadata get_metadata() {
+  blit::GameMetadata ret;
+
+  ret.title = metadata_title;
+  ret.author = metadata_author;
+  ret.description = metadata_author;
+  ret.version = metadata_version;
+  ret.url = metadata_url;
+  ret.category = metadata_category;
+
+  return ret;
+}
+
 extern Multiplayer *blit_multiplayer;
 bool blit_is_multiplayer_connected() {
 	return blit_multiplayer->is_connected();
@@ -184,6 +197,8 @@ void System::run() {
 	blit::api.is_multiplayer_connected = blit_is_multiplayer_connected;
 	blit::api.set_multiplayer_enabled = blit_set_multiplayer_enabled;
 	blit::api.send_message = blit_send_message;
+
+  blit::api.get_metadata = ::get_metadata;
 
 	::set_screen_mode(blit::lores);
 

--- a/32blit-sdl/UserCode.hpp
+++ b/32blit-sdl/UserCode.hpp
@@ -9,3 +9,5 @@ extern const char *metadata_title;
 extern const char *metadata_author;
 extern const char *metadata_description;
 extern const char *metadata_version;
+extern const char *metadata_url;
+extern const char *metadata_category;

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -154,6 +154,29 @@ static const char *get_launch_path() {
   return persist.launch_path;
 }
 
+static GameMetadata get_metadata() {
+  GameMetadata ret;
+
+  auto meta = blit_get_running_game_metadata();
+  if(meta) {
+    ret.title = meta->title;
+    ret.author = meta->author;
+    ret.description = meta->description;
+    ret.version = meta->version;
+
+    if(memcmp(meta + 1, "BLITTYPE", 8) == 0) {
+      auto type_meta = reinterpret_cast<RawTypeMetadata *>(reinterpret_cast<char *>(meta) + sizeof(*meta) + 8);
+      ret.url = type_meta->url;
+      ret.category = type_meta->category;
+    } else {
+      ret.url = "";
+      ret.category = "none";
+    }
+  }
+
+  return ret;
+}
+
 static void do_render() {
   if(display::needs_render) {
     blit::render(blit::now());
@@ -357,6 +380,8 @@ void blit_init() {
     blit::api.is_multiplayer_connected = multiplayer::is_connected;
     blit::api.set_multiplayer_enabled = multiplayer::set_enabled;
     blit::api.send_message = multiplayer::send_message;
+
+    blit::api.get_metadata = ::get_metadata;
 
   display::init();
 

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -7,6 +7,7 @@
 #include "file.hpp"
 #include "../audio/audio.hpp"
 #include "../engine/input.hpp"
+#include "../engine/version.hpp"
 #include "../graphics/jpeg.hpp"
 #include "../graphics/surface.hpp"
 #include "../types/vec2.hpp"
@@ -80,6 +81,8 @@ namespace blit {
 
     const uint8_t *(*flash_to_tmp)(const std::string &filename, uint32_t &size);
     void (*tmp_file_closed)(const uint8_t *ptr);
+
+    GameMetadata (*get_metadata)();
   };
   #pragma pack(pop)
 

--- a/32blit/engine/version.cpp
+++ b/32blit/engine/version.cpp
@@ -1,5 +1,6 @@
 #include "version.hpp"
 #include "version_defs.hpp"
+#include "api_private.hpp"
 
 namespace blit {
   const char *get_version_string() {
@@ -7,5 +8,9 @@ namespace blit {
   }
   const char *get_build_date() {
     return BLIT_BUILD_DATE;
+  }
+
+  GameMetadata get_metadata() {
+    return api.get_metadata();
   }
 }

--- a/32blit/engine/version.hpp
+++ b/32blit/engine/version.hpp
@@ -3,4 +3,15 @@
 namespace blit {
   const char *get_version_string();
   const char *get_build_date();
+
+  struct GameMetadata {
+    const char *title = nullptr;
+    const char *author = nullptr;
+    const char *description = nullptr;
+    const char *version = nullptr;
+    const char *url = nullptr;
+    const char *category = nullptr;
+  };
+
+  GameMetadata get_metadata();
 }


### PR DESCRIPTION
Adds an API that allows games to get their metadata at runtime (just the strings, as those are already in both builds). Requires https://github.com/32blit/32blit-tools/pull/73 for SDL url/category to not be blank.