### PR TITLE
Document Windows builds without needing WSL or a full Visual Studio install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Refer to the OS specific docs:
 * [Linux](docs/Linux.md)
 * [Linux - ChromeOS](docs/ChromeOS.md)
 * [Windows - Visual Studio](docs/Windows-VisualStudio.md)
+* [Windows - Command Line / other editor](docs/Windows.md)
 * [Windows - WSL (Advanced)](docs/Windows-WSL.md)
 * [macOS](docs/macOS.md)
 

--- a/docs/VSCode.md
+++ b/docs/VSCode.md
@@ -5,12 +5,13 @@ These instructions cover setting up Visual Studio Code to build the CMake projec
 A working knowledge of using and configuring Visual Studio Code is assumed.
 
 - [Requirements](#requirements)
-- [Mac specific setup](#mac-specific-setup)
 - [Initial setup for local builds](#initial-setup-for-local-builds)
 - [IntelliSense](#intellisense)
 - [CMake Arguments](#cmake-arguments)
 - [Debugger configuration](#debugger-configuration)
 - [Building for 32Blit](#building-for-32blit)
+- [Troubleshooting](#troubleshooting)
+  - [Debugging on macOS](#debugging-on-macos)
 
 ## Requirements
 
@@ -21,23 +22,6 @@ You'll need to install:
  - The [CMake Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
 
 Then open the cloned repository with "Open folder...".
-
-## Mac specific setup
-
-If you are running Catalina or higher, you may find difficulty in debugging local builds. To fix this, you need to install the [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension. Add a 'Build and attach' configuration like so:
-
-- Add a configuration with Debug > Add Configuration
-- Paste in the following
-
-``` json
-{
-   "name": "Launch and Debug",
-   "type": "lldb",
-   "request": "launch",
-   "program": "${command:cmake.launchTargetPath}"
-}
-```
-Now, when you want to attach the debugger, run with that configuration and now your breakpoints will be respected 🎉
 
 ## Initial setup for local builds
 You should get a notification asking if you want to configure the project. Click "Yes" and select "[Unspecified]" from the "Select a Kit" dropdown for a local build with the default compiler.
@@ -79,3 +63,21 @@ Add this to the list:
 (Replacing `/path/to/32blit-sdk`, with the actual path.)
 
 You should now be able to select "32Blit" as a kit. ("CMake: Change Kit" from the command palette or the button displaying the current kit at the bottom of the window). If you select a target ending with .flash from the list next to the "⚙ Build:" button, that example will be flashed to your device when you build.
+
+## Troubleshooting
+
+### Debugging on macOS
+If you are running Catalina or higher, you may find difficulty in debugging local builds. To fix this, you need to install the [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension. Add a 'Build and attach' configuration like so:
+
+- Add a configuration with Debug > Add Configuration
+- Paste in the following
+
+``` json
+{
+   "name": "Launch and Debug",
+   "type": "lldb",
+   "request": "launch",
+   "program": "${command:cmake.launchTargetPath}"
+}
+```
+Now, when you want to attach the debugger, run with that configuration and now your breakpoints will be respected 🎉

--- a/docs/VSCode.md
+++ b/docs/VSCode.md
@@ -5,7 +5,6 @@ These instructions cover setting up Visual Studio Code to build the CMake projec
 A working knowledge of using and configuring Visual Studio Code is assumed.
 
 - [Requirements](#requirements)
-- [Windows specific setup](#windows-specific-setup)
 - [Mac specific setup](#mac-specific-setup)
 - [Initial setup for local builds](#initial-setup-for-local-builds)
 - [IntelliSense](#intellisense)
@@ -22,13 +21,6 @@ You'll need to install:
  - The [CMake Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
 
 Then open the cloned repository with "Open folder...".
-
-## Windows specific setup
-
-Windows needs a little help to find the required dependencies for local builds.
-
- - First download SDL as described in the [Visual Studio](Windows-VisualStudio.md) docs.
- - Add `"SDL2_DIR": "${workspaceRoot}/vs/sdl/"` to `configureSettings` (See "CMake Arguments" below)
 
 ## Mac specific setup
 

--- a/docs/VSCode.md
+++ b/docs/VSCode.md
@@ -12,6 +12,8 @@ A working knowledge of using and configuring Visual Studio Code is assumed.
 - [Building for 32Blit](#building-for-32blit)
 - [Troubleshooting](#troubleshooting)
   - [Debugging on macOS](#debugging-on-macos)
+  - ["Unable to determine what CMake generator to use." on Windows](#unable-to-determine-what-cmake-generator-to-use-on-windows)
+  - [`Shift` + `F5` to run not working when using a Visual Studio kit](#shift--f5-to-run-not-working-when-using-a-visual-studio-kit)
 
 ## Requirements
 
@@ -81,3 +83,9 @@ If you are running Catalina or higher, you may find difficulty in debugging loca
 }
 ```
 Now, when you want to attach the debugger, run with that configuration and now your breakpoints will be respected 🎉
+
+### "Unable to determine what CMake generator to use." on Windows
+You may need to run `code` from the VS Developer Command Prompt for CMake Tools to be able to find all of the required build tools.
+
+### `Shift` + `F5` to run not working when using a Visual Studio kit
+The CMake Visual studio generators may result in the SDL2 DLLs getting copied to the wrong place (DLLs in `build/`, exe in `build/Debug/`). You can work around this by adding `"cmake.generator": "NMake Makefiles"` to your settings.json to force the NMake generator instead.

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -1,0 +1,79 @@
+# Building & Running on Windows <!-- omit in toc -->
+
+These instructions cover building 32blit on Windows (without WSL or a full Visual Studio install).
+
+- [Prerequisites](#prerequisites)
+  - [Building & Running on 32Blit](#building--running-on-32blit)
+  - [Building & Running Locally](#building--running-locally)
+    - [Build Everything](#build-everything)
+
+# Prerequisites
+
+You'll need to install:
+
+ - [Git for Windows](https://git-scm.com/download/win)
+ - [Python] (https://www.python.org/downloads/)
+ - The [Visual Studio build tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) (For local builds, select "C++ build tools"). This includes a copy of CMake.
+ - The [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) (For 32blit device builds, use the 9-2020-q2-update version). Make sure to select the "Add path to environment variable" at the end of the setup.
+
+Now open "Developer Command Prompt for VS 2019" and install the 32blit tools:
+```
+py -m pip install 32blit
+```
+(Keep this open for building later)
+
+This may result in a waning similar to:
+
+```
+WARNING: The script 32blit.exe is installed in 'C:\Users\[Name]\AppData\Local\Programs\Python\Python39\Scripts' which is not on PATH.
+```
+
+You will either need to add that to your PATH, or run the tools as `py -m ttblit ...` instead of `32blit ...`.
+
+## Building & Running on 32Blit
+
+If you want to run code on 32Blit, you should now refer to [Building & Running On 32Blit](32blit.md). You will need to add `-G"NMake Makefiles"` to your cmake commands and use `nmake` instead of `make`. For example:
+```
+mkdir build.stm32
+cd build.stm32
+cmake -G"NMake Makefiles" -DCMAKE_TOOLCHAIN_FILE=../32blit.toolchain ..
+nmake
+```
+
+## Building & Running Locally
+
+Set up the 32Blit Makefile from the root of the repository with the following commands:
+
+```shell
+mkdir build
+cd build
+cmake -G"NMake Makefiles" ..
+```
+
+Now to make any example, type:
+
+```
+nmake example-name
+```
+
+For example:
+
+```
+nmake raycaster
+```
+
+This will produce `examples/raycaster/raycaster.exe` which you should run with:
+
+```
+.\examples\raycaster\raycaster
+```
+
+### Build Everything
+
+Alternatively you can build everything by just typing:
+
+```
+nmake
+```
+
+When the build completes you should be able to run any example.


### PR DESCRIPTION
This is the thing I keep mentioning whenever a Windows user has setup problems... Finally got around to working out what was required. This was tested on a "clean" Windows VM.

The basic Windows instructions are now very similar to the Linux/macOS setup. I was tempted to replace every occurrence of `make x` in the docs with `cmake --build . --target x` since that works with every CMake generator. (Instead of "follow these docs, but use nmake instead of make")

I guess the "you need a cross-compile env" bits in 32blit.md and 32blit-firmware.md could link to this too.

(Apparently the default windows Python install has `py` in PATH and not `python` or `python3`...)