### PR TITLE
Split api_version to handle breaking changes

### DIFF
--- a/32blit-stm32/startup_user.cpp
+++ b/32blit-stm32/startup_user.cpp
@@ -6,17 +6,20 @@ extern void update(uint32_t time);
 extern void render(uint32_t time);
 
 extern "C" bool cpp_do_init() {
-    if(blit::api.version < blit::api_version)
-        return false;
+  if(blit::api.version_major != blit::api_version_major)
+    return false;
 
-    blit::update = update;
-    blit::render = render;
+  if(blit::api.version_minor < blit::api_version_minor)
+    return false;
 
-    blit::set_screen_mode(blit::ScreenMode::lores);
+  blit::update = update;
+  blit::render = render;
 
-    init();
+  blit::set_screen_mode(blit::ScreenMode::lores);
 
-    return true;
+  init();
+
+  return true;
 }
 
 extern "C" void _exit(int code) {

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -17,11 +17,12 @@ namespace blit {
 
   using AllocateCallback = uint8_t *(*)(size_t);
 
-  constexpr uint32_t api_version = 0;
+  constexpr uint16_t api_version_major = 0, api_version_minor = 0;
 
   #pragma pack(push, 4)
   struct API {
-    uint32_t version = api_version;
+    uint16_t version_major = api_version_major;
+    uint16_t version_minor = api_version_minor;
 
     ButtonState buttons;
     float hack_left;


### PR DESCRIPTION
Should be avoided, but handling it instead of crashing is probably still a good idea. Also, it's not like we were going to need 4 billion API versions...

version_major = breaking changes
version_minor = non-breaking API additions.


