### PR TITLE
Fix MinGW SDL DLLs

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
 	# find SDL2_image
 	# TODO: may need to be more complicated
 	find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
-		HINTS ${SDL2_DIR} ${SDL2_DIR}../../../
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES SDL2 include/SDL2 include
 	)
 
@@ -68,31 +68,31 @@ else()
 
 	find_library(SDL2_IMAGE_LIBRARY
 		NAMES SDL2_image
-		HINTS ${SDL2_DIR} ${SDL2_DIR}../../../
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
 	)
 
 	# dlls
 	find_file(SDL2_IMAGE_DLL SDL2_image.dll
-		HINTS ${SDL2_DIR} ${SDL2_DIR}../../../
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
 	)
 
 	#SDL_net
 	find_path(SDL2_NET_INCLUDE_DIR SDL_net.h
-		HINTS ${SDL2_DIR} ${SDL2_DIR}../../../
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES SDL2 include/SDL2 include
 	)
 
 	find_library(SDL2_NET_LIBRARY
 		NAMES SDL2_net
-		HINTS ${SDL2_DIR} ${SDL2_DIR}../../../
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
 	)
 
 	# dlls
 	find_file(SDL2_NET_DLL SDL2_net.dll
-		HINTS ${SDL2_DIR} ${SDL2_DIR}../../../
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
 	)
 

--- a/mingw.toolchain
+++ b/mingw.toolchain
@@ -13,7 +13,3 @@ set(CMAKE_CXX_FLAGS_INIT "-static-libstdc++ -static-libgcc -Wl,-Bstatic -lstdc++
 if(EXISTS "${SDL2_PREFIX}/bin/SDL2.dll")
 	set(SDL2_DLL "${SDL2_PREFIX}/bin/SDL2.dll")
 endif()
-
-if(EXISTS "${SDL2_PREFIX}/bin/SDL2_image.dll")
-	set(SDL2_IMAGE_DLL "${SDL2_PREFIX}/bin/SDL2_image.dll")
-endif()


### PR DESCRIPTION
If SDL2_DIR didn't have a trailing slash some of the find_*s would fail, resulting in MinGW not copying some of the dlls.

The MinGW toolchain defaults SDL2_DIR to something without a trailing slash...