### PR TITLE
Launch/API fixes

### DIFF
--- a/32blit-stm32/Inc/32blit.h
+++ b/32blit-stm32/Inc/32blit.h
@@ -33,7 +33,7 @@ extern void blit_process_input();
 
 // Switching execution.
 // Address is relative to the start of flash, ignored if switching to firmware
-extern void blit_switch_execution(uint32_t address, bool force_game);
+extern bool blit_switch_execution(uint32_t address, bool force_game);
 extern bool blit_user_code_running();
 extern "C" void blit_reset_with_error();
 extern void blit_enable_user_code();

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -454,8 +454,7 @@ static bool launch_game_from_sd(const char *path, bool auto_delete = false) {
     if(auto_delete)
       ::remove_file(path);
 
-    blit_switch_execution(launch_offset, true);
-    return true;
+    return blit_switch_execution(launch_offset, true);
   }
 
   blit_enable_user_code();
@@ -468,8 +467,7 @@ static bool launch_file_from_sd(const char *path) {
   persist.launch_path[0] = 0;
 
   if(strncmp(path, "flash:/", 7) == 0) {
-    blit_switch_execution(atoi(path + 7) * qspi_flash_sector_size, true);
-    return true;
+    return blit_switch_execution(atoi(path + 7) * qspi_flash_sector_size, true);
   }
 
   uint32_t launch_offset = 0xFFFFFFFF;
@@ -495,8 +493,7 @@ static bool launch_file_from_sd(const char *path) {
     // set the path to the file to launch
     strncpy(persist.launch_path, path, sizeof(persist.launch_path));
 
-    blit_switch_execution(launch_offset, true);
-    return true;
+    return blit_switch_execution(launch_offset, true);
   }
 
   // .blit file, install/launch

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -988,8 +988,6 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
           progress.update(m_uParseIndex + 1);
 
           if(bEOS) {
-            handle_data_end(result != srError);
-
             if(result != srError) {
               while(CDC_Transmit_HS((uint8_t *)"32BL__OK", 8) == USBD_BUSY){}
               if(dest == Destination::Flash) {
@@ -1001,6 +999,7 @@ CDCCommandHandler::StreamResult FlashLoader::StreamData(CDCDataStream &dataStrea
               result = srFinish;
             }
             progress.hide();
+            handle_data_end(result != srError);
           }
 
           m_uParseIndex++;

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -606,6 +606,15 @@ static void tmp_file_closed(const uint8_t *ptr) {
   cached_file_in_tmp = false;
 }
 
+static void start_launcher() {
+  if(launcher_offset == 0xFFFFFFFF)
+    return;
+
+  // if the launcher fails to start it's incompatible, ignore it
+  if(!blit_switch_execution(launcher_offset, false))
+    launcher_offset = 0xFFFFFFFF;
+}
+
 void init() {
   api.launch = launch_file_from_sd;
   api.erase_game = erase_flash_game;
@@ -654,13 +663,13 @@ void init() {
 
       if(yes)
         blit_switch_execution(persist.last_game_offset, false);
-      else if(launcher_offset != 0xFFFFFFFF)
-        blit_switch_execution(launcher_offset, false);
+      else
+        start_launcher();
 
       persist.reset_error = false;
     });
-  } else if(launcher_offset != 0xFFFFFFFF)
-    blit_switch_execution(launcher_offset, false);
+  } else
+    start_launcher();
 }
 
 void render(uint32_t time) {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -655,10 +655,15 @@ void init() {
   }
 
   // auto-launch
-  if(persist.reset_target == prtGame)
-    blit_switch_execution(persist.last_game_offset, false);
+  if(persist.reset_target == prtGame) {
+    if(!blit_switch_execution(persist.last_game_offset, false)) {
+      // failed to start, notify user and switch to launcher
+      dialog.show("Oops!", "Failed to launch game!", [](bool yes) {
+        start_launcher();
+      }, false);
+    }
   // error reset handling
-  else if(persist.reset_error) {
+  } else if(persist.reset_error) {
     dialog.show("Oops!", "Restart game?", [](bool yes){
 
       if(yes)

--- a/launcher-shared/dialog.hpp
+++ b/launcher-shared/dialog.hpp
@@ -7,11 +7,13 @@ struct Dialog {
 
   using AnswerFunc = void(*)(bool);
   AnswerFunc on_answer;
+  bool is_question;
 
-  void show(std::string title, std::string message, AnswerFunc on_answer) {
+  void show(std::string title, std::string message, AnswerFunc on_answer, bool is_question = true) {
     this->title = title;
     this->message = message;
     this->on_answer = on_answer;
+    this->is_question = is_question;
   }
 
   bool update() {
@@ -68,10 +70,16 @@ struct Dialog {
     screen.pen = Pen(255, 255, 255);
     screen.text(message, minimal_font, Rect(dialog_rect.x + 6, dialog_rect.y + header_height + 5, dialog_rect.w - 12, 45));
 
-    screen.text("No      Yes    ", minimal_font, Rect(dialog_rect.x + 1, dialog_rect.y + dialog_rect.h - 17, dialog_rect.w - 2, 16 + minimal_font.spacing_y), true, TextAlign::center_right);
+    if(is_question) {
+      screen.text("No      Yes    ", minimal_font, Rect(dialog_rect.x + 1, dialog_rect.y + dialog_rect.h - 17, dialog_rect.w - 2, 16 + minimal_font.spacing_y), true, TextAlign::center_right);
 
-    button_icon(Point(dialog_rect.x + 185, dialog_rect.y + 71), Button::B);
-    button_icon(Point(dialog_rect.x + 218, dialog_rect.y + 71), Button::A);
+      button_icon(Point(dialog_rect.x + 185, dialog_rect.y + 71), Button::B);
+      button_icon(Point(dialog_rect.x + 218, dialog_rect.y + 71), Button::A);
+    } else {
+      screen.text("OK    ", minimal_font, Rect(dialog_rect.x + 1, dialog_rect.y + dialog_rect.h - 17, dialog_rect.w - 2, 16 + minimal_font.spacing_y), true, TextAlign::center_right);
+
+      button_icon(Point(dialog_rect.x + 218, dialog_rect.y + 71), Button::A);
+    }
   }
 
 };


### PR DESCRIPTION
- Fixed an incompatible launcher resulting in a reset loop (now handled the same as no launcher)
- Added a message when a game fails to launch
- Fixed flashing a game when the same game was running (it would get erased and crash when resuming it)

The special case of "flashing a launcher always resets" is now "flashing the running game always resets".

Tested with an incompatible launcher/game and flashing the same game twice.

Need to fix the tools to not error out when the device resets after flashing...