### PR TITLE
A few small fixes

### DIFF
--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -299,10 +299,10 @@ namespace blit {
     if (dr.empty())
       return; // after clipping there is nothing to draw
 
-    uint8_t left = dr.x - p.x;
-    uint8_t top = dr.y - p.y;
-    uint8_t right = sprite.w - (sprite.w - dr.w) + left - 1;
-    uint8_t bottom = sprite.h - (sprite.h - dr.h) + top - 1;
+    int left = dr.x - p.x;
+    int top = dr.y - p.y;
+    int right = sprite.w - (sprite.w - dr.w) + left - 1;
+    int bottom = sprite.h - (sprite.h - dr.h) + top - 1;
 
     if (t & SpriteTransform::VERTICAL) {
       top    = sprite.h - 1 - top;
@@ -323,11 +323,11 @@ namespace blit {
     uint32_t dest_offset = offset(dr);
     uint32_t src_offset;
 
-    uint8_t y_count = dr.h;
-    uint8_t y = top;
+    int y_count = dr.h;
+    int y = top;
     do {
-      uint8_t x_count = dr.w;
-      uint8_t x = left;
+      int x_count = dr.w;
+      int x = left;
 
       if (t & SpriteTransform::XYSWAP)
         src_offset = sprites->offset(sprite.x + y, sprite.y + x);
@@ -378,10 +378,11 @@ namespace blit {
     uint32_t dest_offset = offset(dr);
     uint32_t src_offset;
 
-    uint8_t y_count = dr.h;
+    int y_count = dr.h;
     float y = top;
+
     do {
-      uint8_t x_count = dr.w;
+      int x_count = dr.w;
       float x = left;
       do {
         if (t & SpriteTransform::XYSWAP)

--- a/32blit/types/point.hpp
+++ b/32blit/types/point.hpp
@@ -13,13 +13,15 @@ namespace blit {
     constexpr Point(int32_t x, int32_t y) : x(x), y(y) {}
     constexpr Point(Vec2 v) : x(int32_t(v.x)), y(int32_t(v.y)) {}
 
+    explicit constexpr operator Vec2() const {return Vec2(x, y);}
+
     inline Point& operator-= (const Point &a) { x -= a.x; y -= a.y; return *this; }
     inline Point& operator+= (const Point &a) { x += a.x; y += a.y; return *this; }
     inline Point& operator*= (const float a) { x = static_cast<int32_t>(x * a); y = static_cast<int32_t>(y * a); return *this; }
     inline Point& operator*= (const Mat3 &a) { this->transform(a); return *this; }
     inline Point& operator/= (const int32_t a) { x /= a;   y /= a;   return *this; }
 
-    void   transform(const Mat3 &m) {     
+    void transform(const Mat3 &m) {
       auto tx = static_cast<float>(x); auto ty = static_cast<float>(y);
       this->x = static_cast<int32_t>(m.v00 * tx + m.v01 * ty + m.v02);
       this->y = static_cast<int32_t>(m.v10 * tx + m.v11 * ty + m.v12);

--- a/32blit/types/size.hpp
+++ b/32blit/types/size.hpp
@@ -18,11 +18,11 @@ namespace blit {
     inline Size& operator*= (const int a) { w = static_cast<int32_t>(w * a); h = static_cast<int32_t>(h * a); return *this; }
     inline Size& operator/= (const int a) { w = static_cast<int32_t>(w / a); h = static_cast<int32_t>(h / a); return *this; }
 
-    bool empty() { return w <= 0 || h <= 0; }
+    constexpr bool empty() const { return w <= 0 || h <= 0; }
 
-    int32_t area() { return w * h; }
+    constexpr int32_t area() const { return w * h; }
 
-    bool contains(const Point &p) {
+    constexpr bool contains(const Point &p) const {
       return p.x >= 0 && p.y >= 0 && p.x < w && p.y < h;
     }
 

--- a/32blit/types/vec3.cpp
+++ b/32blit/types/vec3.cpp
@@ -15,11 +15,11 @@ extern "C" {
 namespace blit {
 
   void Vec3::transform(const Mat4 &m) {
-    float w = m.v30 * this->x + m.v31 * this->y + m.v32 * -this->z + m.v33;
+    float w = m.v30 * this->x + m.v31 * this->y + m.v32 * this->z + m.v33;
     float tx = x; float ty = y; float tz = z;
-    this->x = (m.v00 * tx + m.v01 * ty + m.v02 * -tz + m.v03) / w;
-    this->y = (m.v10 * tx + m.v11 * ty + m.v12 * -tz + m.v13) / w;
-    this->z = (m.v20 * tx + m.v21 * ty + m.v22 * -tz + m.v23) / w;
+    this->x = (m.v00 * tx + m.v01 * ty + m.v02 * tz + m.v03) / w;
+    this->y = (m.v10 * tx + m.v11 * ty + m.v12 * tz + m.v13) / w;
+    this->z = (m.v20 * tx + m.v21 * ty + m.v22 * tz + m.v23) / w;
   }
 
   void   Vec3::normalize() { float d = this->length(); x /= d; y /= d; z /= d; }


### PR DESCRIPTION
First one fixes `vec.transform(Mat4::identity())` having an effect. Second one makes it so you can do:
```c++
static constexpr blit::Size size{96, 96};
uint8_t data[size.area()];

blit::Surface surface{data, blit::PixelFormat::P, size};
```
(From my minimap code)

There are probably a lot more methods that could be `const`/`constexpr`.