### PR TITLE
Handle metadata with quotes in 32blit-sdl

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -252,15 +252,17 @@ function(blit_metadata TARGET FILE)
 		set_source_files_properties(${ICON} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 	endif()
 
-	file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_metadata.cpp
-		CONTENT "
-const char *metadata_title = \"${METADATA_TITLE}\";
-const char *metadata_author = \"${METADATA_AUTHOR}\";
-const char *metadata_description = \"${METADATA_DESCRIPTION}\";
-const char *metadata_version = \"${METADATA_VERSION}\";
-const char *metadata_url = \"${METADATA_URL}\";
-const char *metadata_category = \"${METADATA_CATEGORY}\";
-		"
+	string(CONFIGURE "
+const char *metadata_title = \"\${METADATA_TITLE}\";
+const char *metadata_author = \"\${METADATA_AUTHOR}\";
+const char *metadata_description = \"\${METADATA_DESCRIPTION}\";
+const char *metadata_version = \"\${METADATA_VERSION}\";
+const char *metadata_url = \"\${METADATA_URL}\";
+const char *metadata_category = \"\${METADATA_CATEGORY}\";"
+		METADATA_CONTENT ESCAPE_QUOTES
 	)
+
+	file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_metadata.cpp CONTENT "${METADATA_CONTENT}")
+
 	target_sources(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/_metadata.cpp)
 endfunction()


### PR DESCRIPTION
I just exploded my build a bit...

Another case of needing to do a bit more work because the magic command that fixes it was only added "recently".


(This only works if `metadata.cmake` has its quotes escaped... which it doesn't.)