### PR TITLE
More multiplayer improvements

### DIFF
--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -78,12 +78,19 @@ void Multiplayer::update() {
             continue;
 
           if(memcmp(head_buf, "32BLUSER", 8) == 0) {
-            read = SDLNet_TCP_Recv(socket, head_buf, 2);
+            // get the length
+            int off = 0;
 
-            if(read <= 0) {
-              disconnect();
-              return;
-            }
+            do {
+              read = SDLNet_TCP_Recv(socket, head_buf + off, 2 - off);
+
+              if(read <= 0) {
+                disconnect();
+                return;
+              }
+
+              off += read;
+            } while(off != 2);
 
             recv_len = head_buf[0] | (head_buf[1] << 8);
             recv_buf = new uint8_t[recv_len];

--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -86,10 +86,10 @@ void Multiplayer::update() {
           } else if(memcmp(head, "32BLMLTI", 8) == 0) {
             // handle the handshake packet
             SDLNet_TCP_Recv(socket, head, 1);
-            handshake = head[0] == 1;
+            handshake = head[0] != 0;
 
-            if(mode == Mode::Connect)
-              SDLNet_TCP_Send(socket, "32BLMLTI\1", 9);
+            if(mode == Mode::Connect && head[0] == 1)
+              SDLNet_TCP_Send(socket, "32BLMLTI\2", 9);
 
           } else {
             std::cerr << "Unexpected header: " << std::string(reinterpret_cast<char *>(head), 8) << std::endl;

--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -153,9 +153,9 @@ void Multiplayer::setup() {
             std::cerr << "Failed to resolve host: " << SDLNet_GetError() << std::endl;
             return;
         }
-    }
 
-    socket = SDLNet_TCP_Open(&ip);
+        socket = SDLNet_TCP_Open(&ip);
+    }
 
     if(!socket && mode != Mode::Connect) {
         // try hosting instead unless connecting was specified

--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -51,6 +51,9 @@ void Multiplayer::update() {
               std::cout << (ip >> 24) << "." << ((ip >> 16) & 0xFF) << "." << ((ip >> 8) & 0xFF) << "." << (ip & 0xFF) << " connected" << std::endl;
 
               SDLNet_TCP_AddSocket(sock_set, socket);
+
+              // stop listening now
+              stop_listening();
           }
       }
 
@@ -187,4 +190,11 @@ void Multiplayer::disconnect() {
 
     SDLNet_TCP_Close(socket);
     socket = nullptr;
+}
+
+void Multiplayer::stop_listening() {
+    SDLNet_TCP_DelSocket(sock_set, listen_socket);
+
+    SDLNet_TCP_Close(listen_socket);
+    listen_socket = nullptr;
 }

--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -54,6 +54,11 @@ void Multiplayer::update() {
           uint8_t head[10];
           auto read = SDLNet_TCP_Recv(socket, head, 10);
 
+          if(read <= 0) {
+            disconnect();
+            return;
+          }
+
           recv_len = head[8] | (head[9] << 8);
           recv_buf = new uint8_t[recv_len];
           recv_off = 0;
@@ -63,8 +68,8 @@ void Multiplayer::update() {
       }
 
       auto read = SDLNet_TCP_Recv(socket, recv_buf + recv_off, recv_len - recv_off);
-      if(read < 0) {
-          // failed
+      if(read <= 0) {
+          // failed/disconnected
           delete[] recv_buf;
           recv_buf = nullptr;
           disconnect();

--- a/32blit-sdl/Multiplayer.hpp
+++ b/32blit-sdl/Multiplayer.hpp
@@ -25,6 +25,7 @@ class Multiplayer final {
     private:
         void setup();
         void disconnect();
+        void stop_listening();
 
         Mode mode;
         std::string address;

--- a/32blit-sdl/Multiplayer.hpp
+++ b/32blit-sdl/Multiplayer.hpp
@@ -29,7 +29,7 @@ class Multiplayer final {
 
         Mode mode;
         std::string address;
-        bool enabled = false;
+        bool enabled = false, handshake = false;
 
         TCPsocket socket = nullptr, listen_socket = nullptr;
         SDLNet_SocketSet sock_set = nullptr;

--- a/32blit-sdl/Multiplayer.hpp
+++ b/32blit-sdl/Multiplayer.hpp
@@ -32,6 +32,11 @@ class Multiplayer final {
 
         TCPsocket socket = nullptr, listen_socket = nullptr;
         SDLNet_SocketSet sock_set = nullptr;
+        IPaddress ip;
+        bool have_ip = false;
+
+        static const int retry_interval = 5000;
+        Uint32 last_connect_time = 0;
 
         uint8_t *recv_buf = nullptr;
         uint16_t recv_len = 0, recv_off = 0;

--- a/32blit-sdl/Multiplayer.hpp
+++ b/32blit-sdl/Multiplayer.hpp
@@ -37,6 +37,9 @@ class Multiplayer final {
         static const int retry_interval = 5000;
         Uint32 last_connect_time = 0;
 
+        uint8_t head_buf[8];
+        int head_off = 0;
+
         uint8_t *recv_buf = nullptr;
         uint16_t recv_len = 0, recv_off = 0;
 };

--- a/32blit-sdl/Multiplayer.hpp
+++ b/32blit-sdl/Multiplayer.hpp
@@ -32,8 +32,6 @@ class Multiplayer final {
 
         TCPsocket socket = nullptr, listen_socket = nullptr;
         SDLNet_SocketSet sock_set = nullptr;
-        IPaddress ip;
-        bool have_ip = false;
 
         static const int retry_interval = 5000;
         Uint32 last_connect_time = 0;

--- a/32blit-stm32/Inc/CDCCommandStream.h
+++ b/32blit-stm32/Inc/CDCCommandStream.h
@@ -58,6 +58,7 @@ private:
 	uint8_t			m_header[4] = { '3', '2', 'B', 'L' };
 	uint8_t			m_uHeaderScanPos = 0;
 	uint8_t			m_uCommandScanPos = 0;
+	CDCCommandHandler::CDCFourCC uCommand = 0;
 
 
 	CDCCommandHandler														*m_pCurrentCommandHandler;

--- a/32blit-stm32/Inc/CDCDataStream.h
+++ b/32blit-stm32/Inc/CDCDataStream.h
@@ -33,6 +33,11 @@ public:
 		return true;
 	}
 
+  void Clear()
+  {
+    m_uLen = 0;
+  }
+
 	uint32_t GetStreamLength(void)
 	{
 		return m_uLen;

--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -76,8 +76,6 @@ uint8_t CDCCommandStream::Stream(uint8_t *data, uint32_t len)
 	blit_disable_ADC();
 	uint8_t   *pScanPos  = data;
 
-	CDCCommandHandler::CDCFourCC uCommand   = 0;
-
   while(pScanPos < (data+len))
   {
     if(m_state == stDetect)
@@ -111,7 +109,7 @@ uint8_t CDCCommandStream::Stream(uint8_t *data, uint32_t len)
         while((m_state == stDetect) && (m_uCommandScanPos < 4))
         {
           uint8_t  *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
-          if(pScanPos > (data + len)) // rest in next packet
+          if(pScanPos >= (data + len)) // rest in next packet
             m_state = stDetectCommandWord;
           else
           {

--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -78,118 +78,129 @@ uint8_t CDCCommandStream::Stream(uint8_t *data, uint32_t len)
 
 	CDCCommandHandler::CDCFourCC uCommand   = 0;
 
-	if(m_state == stDetect)
-	{
-		bool bHeaderFound = false;
-		while ((!bHeaderFound) && (pScanPos < (data+len)))
-		{
-			if(*pScanPos == m_header[m_uHeaderScanPos])
-			{
-				if(m_uHeaderScanPos == 3)
-				{
-					// header found
-					bHeaderFound = true;
-					m_uHeaderScanPos = 0;
-					m_uCommandScanPos = 0;
-				}
-				else
-					m_uHeaderScanPos++;
-			}
-			else
-			{
-				m_uHeaderScanPos = 0;
-				m_uCommandScanPos = 0;
-			}
-			pScanPos++;
-		}
+  while(pScanPos < (data+len))
+  {
+    if(m_state == stDetect)
+    {
+      bool bHeaderFound = false;
+      while ((!bHeaderFound) && (pScanPos < (data+len)))
+      {
+        if(*pScanPos == m_header[m_uHeaderScanPos])
+        {
+          if(m_uHeaderScanPos == 3)
+          {
+            // header found
+            bHeaderFound = true;
+            m_uHeaderScanPos = 0;
+            m_uCommandScanPos = 0;
+          }
+          else
+            m_uHeaderScanPos++;
+        }
+        else
+        {
+          m_uHeaderScanPos = 0;
+          m_uCommandScanPos = 0;
+        }
+        pScanPos++;
+      }
 
-		if(bHeaderFound)
-		{
-			// next command byte could be in next call
-			while((m_state == stDetect) && (m_uCommandScanPos < 4))
-			{
-				uint8_t  *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
-				if(pScanPos > (data + len)) // rest in next packet
-					m_state = stDetectCommandWord;
-				else
-				{
-					*pCommandByte = *pScanPos++;
-					if(m_uCommandScanPos == 3)
-					{
-						m_state = stDispatch;
-					}
-					m_uCommandScanPos++;
-				}
-			}
-		}
-	}
-	else
-	{
-		if(m_state == stDetectCommandWord)
-		{
-			while(m_uCommandScanPos < 4)
-			{
-				uint8_t *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
-				*pCommandByte = *pScanPos++;
-				m_uCommandScanPos++;
-			}
-			m_state = stDispatch;
-		}
-	}
+      if(bHeaderFound)
+      {
+        // next command byte could be in next call
+        while((m_state == stDetect) && (m_uCommandScanPos < 4))
+        {
+          uint8_t  *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
+          if(pScanPos > (data + len)) // rest in next packet
+            m_state = stDetectCommandWord;
+          else
+          {
+            *pCommandByte = *pScanPos++;
+            if(m_uCommandScanPos == 3)
+            {
+              m_state = stDispatch;
+            }
+            m_uCommandScanPos++;
+          }
+        }
+      }
+    }
+    else
+    {
+      if(m_state == stDetectCommandWord)
+      {
+        while(m_uCommandScanPos < 4)
+        {
+          uint8_t *pCommandByte = (uint8_t *)(&uCommand)+m_uCommandScanPos;
+          *pCommandByte = *pScanPos++;
+          m_uCommandScanPos++;
+        }
+        m_state = stDispatch;
+      }
+    }
 
-	if(m_state == stDispatch)
-	{
-		m_uRetryCount = 0;
-		m_uDispatchTime = HAL_GetTick();
+    if(m_state == stDispatch)
+    {
+      m_uRetryCount = 0;
+      m_uDispatchTime = HAL_GetTick();
 
-		m_pCurrentCommandHandler = m_commandHandlers[uCommand];
-		if(m_pCurrentCommandHandler)
-		{
-			if(m_pCurrentCommandHandler->StreamInit(uCommand)) {
-				m_state = stProcessing;
-        m_dataStream.Clear(); // make sure there isn't any leftover data in the buffer
-      } else
-			{
-				m_state = stDetect;
-				LogTimeTaken(CDCCommandHandler::srFinish, 0);
-			}
-		}
-		else
-			m_state = stDetect; // No handler go back to detect state
-	}
+      m_pCurrentCommandHandler = m_commandHandlers[uCommand];
+      if(m_pCurrentCommandHandler)
+      {
+        if(m_pCurrentCommandHandler->StreamInit(uCommand)) {
+          m_state = stProcessing;
+          m_dataStream.Clear(); // make sure there isn't any leftover data in the buffer
+        } else
+        {
+          m_state = stDetect;
+          LogTimeTaken(CDCCommandHandler::srFinish, 0);
+        }
+      }
+      else
+        m_state = stDetect; // No handler go back to detect state
+    }
 
-	if(m_state == stProcessing)
-	{
-		m_dataStream.AddData(pScanPos, len - (pScanPos - data));
-		CDCCommandHandler::StreamResult result = m_pCurrentCommandHandler->StreamData(m_dataStream);
+    if(m_state == stProcessing)
+    {
+      auto added_len = len - (pScanPos - data);
 
-		switch(result)
-		{
-			case CDCCommandHandler::srError:
-			case CDCCommandHandler::srFinish:
-			{
-				// handler has finished or failed go back to detect state
-				m_state = stDetect;
-				LogTimeTaken(result, m_pCurrentCommandHandler->GetBytesHandled());
-				blit_enable_ADC();
-			}
-			break;
+      m_dataStream.AddData(pScanPos, added_len);
+      CDCCommandHandler::StreamResult result = m_pCurrentCommandHandler->StreamData(m_dataStream);
 
-			case CDCCommandHandler::srNeedData:
-				m_uRetryCount++;
-				if(m_uRetryCount > 1)
-				{
-					m_state = stDetect;
-					LogTimeTaken(result, m_pCurrentCommandHandler->GetBytesHandled());
-					blit_enable_ADC();
-				}
-			break;
+      switch(result)
+      {
+        case CDCCommandHandler::srError:
+        case CDCCommandHandler::srFinish:
+        {
+          // handler has finished or failed go back to detect state
+          m_state = stDetect;
+          LogTimeTaken(result, m_pCurrentCommandHandler->GetBytesHandled());
+          blit_enable_ADC();
+        }
+        break;
 
-			case CDCCommandHandler::srContinue:
-			break;
-		}
-	}
+        case CDCCommandHandler::srNeedData:
+          m_uRetryCount++;
+          if(m_uRetryCount > 1)
+          {
+            m_state = stDetect;
+            LogTimeTaken(result, m_pCurrentCommandHandler->GetBytesHandled());
+            blit_enable_ADC();
+          }
+        return false;
 
+        case CDCCommandHandler::srContinue:
+        break;
+      }
+
+      // handled all data
+      if(m_dataStream.GetStreamLength() == 0)
+        break;
+      else // some data left, advance scan pos and try again
+        pScanPos += added_len - std::min(added_len, m_dataStream.GetStreamLength());
+    }
+
+  }
 
 	return m_state != stDetect;
 }

--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -145,9 +145,10 @@ uint8_t CDCCommandStream::Stream(uint8_t *data, uint32_t len)
 		m_pCurrentCommandHandler = m_commandHandlers[uCommand];
 		if(m_pCurrentCommandHandler)
 		{
-			if(m_pCurrentCommandHandler->StreamInit(uCommand))
+			if(m_pCurrentCommandHandler->StreamInit(uCommand)) {
 				m_state = stProcessing;
-			else
+        m_dataStream.Clear(); // make sure there isn't any leftover data in the buffer
+      } else
 			{
 				m_state = stDetect;
 				LogTimeTaken(CDCCommandHandler::srFinish, 0);

--- a/32blit-stm32/Src/multiplayer.cpp
+++ b/32blit-stm32/Src/multiplayer.cpp
@@ -15,7 +15,9 @@ extern USBH_HandleTypeDef hUsbHostHS;
 using namespace blit;
 
 namespace multiplayer {
+  bool enabled = false;
   bool peer_connected = false;
+
   void send_handshake();
 
   class CDCUserHandler : public CDCCommandHandler
@@ -39,7 +41,7 @@ namespace multiplayer {
 
       // done, send to user
       if(read == length) {
-        if(api.message_received)
+        if(api.message_received && enabled)
           api.message_received(buf, length);
 
         delete[] buf;
@@ -85,8 +87,6 @@ namespace multiplayer {
 
   CDCUserHandler cdc_user_handler;
   CDCHandshakeHandler cdc_handshake_handler;
-
-  bool enabled = false;
 
   static uint32_t last_handshake_attempt = 0;
 

--- a/32blit-stm32/Src/multiplayer.cpp
+++ b/32blit-stm32/Src/multiplayer.cpp
@@ -18,7 +18,7 @@ namespace multiplayer {
   bool enabled = false;
   bool peer_connected = false;
 
-  void send_handshake();
+  static void send_handshake(bool is_reply = false);
 
   class CDCUserHandler : public CDCCommandHandler
   {
@@ -74,8 +74,8 @@ namespace multiplayer {
       peer_connected = val != 0;
 
       // reply if we're not the host
-      if(peer_connected && !USB_GetMode(USB_OTG_HS))
-        send_handshake();
+      if(val == 1 && !USB_GetMode(USB_OTG_HS))
+        send_handshake(true);
 
       return srFinish;
     }
@@ -114,8 +114,12 @@ namespace multiplayer {
     }
   }
 
-  void send_handshake() {
-    uint8_t buf[]{'3', '2', 'B', 'L', 'M', 'L', 'T','I', enabled ? 1 : 0};
+  static void send_handshake(bool is_reply) {
+    uint8_t val = 0;
+    if(enabled)
+      val = is_reply ? 2 : 1;
+
+    uint8_t buf[]{'3', '2', 'B', 'L', 'M', 'L', 'T','I', val};
     cdc_send(buf, 9);
   }
 


### PR DESCRIPTION
Fixes for SDL connection handling and easier bridging to the STM32 side.

Fun test I came up with for this (assuming no --connect/--listen):

- Start game 1. Starts listening.
- Start game 2. Connects to 1, 1 stops listening.
- Start game 3. Starts listening.
- Start game 4. Connects to 3, 3 stops listening.
- You now have two independent pairs of games open.
- Close 3. 4 disconnects.
- Close 2. 1 starts listening, 4 connects to 1, 1 stops listening again.
- Still have a connection, but neither of the ones we started with!