### PR TITLE
Use .mp4 for video extension

### DIFF
--- a/32blit-sdl/VideoCapture.cpp
+++ b/32blit-sdl/VideoCapture.cpp
@@ -46,7 +46,7 @@ void VideoCapture::start() {
 	auto bt = localtime_xp(std::time(0));
 	std::stringstream filename;
 	filename << name;
-	filename << std::put_time(&bt, "-capture-%Y-%m-%d-%H-%M-%S.mpg");
+	filename << std::put_time(&bt, "-capture-%Y-%m-%d-%H-%M-%S.mp4");
 	start(filename.str().c_str());
 }
 


### PR DESCRIPTION
This stops ffmpeg spamming MPEG related errors at me. (Yes, I'm actually using the video recording stuff...)