### PR TITLE
Tilemap optimisations

### DIFF
--- a/32blit/graphics/blend.cpp
+++ b/32blit/graphics/blend.cpp
@@ -210,12 +210,8 @@ namespace blit {
     do {
       Pen *pen = src->palette ? &src->palette[*s] : (Pen *)s;
 
-      uint16_t a;
-
-      if(src->format == PixelFormat::RGB)
-        a = m ? alpha(*m++, dest->alpha) : dest->alpha;
-      else
-        a = m ? alpha(pen->a, *m++, dest->alpha) : alpha(pen->a, dest->alpha);
+      uint16_t a = src->format == PixelFormat::RGB ? 0 : pen->a;
+      a = m ? alpha(a, *m++, dest->alpha) : alpha(a, dest->alpha);
 
       if (a >= 255) {
         *d++ = pen->r; *d++ = pen->g; *d++ = pen->b; d++;
@@ -240,12 +236,8 @@ namespace blit {
     do {
       Pen *pen = src->palette ? &src->palette[*s] : (Pen *)s;
 
-      uint16_t a;
-
-      if(src->format == PixelFormat::RGB)
-        a = m ? alpha(*m++, dest->alpha) : dest->alpha;
-      else
-        a = m ? alpha(pen->a, *m++, dest->alpha) : alpha(pen->a, dest->alpha);
+      uint16_t a = src->format == PixelFormat::RGB ? 0 : pen->a;
+      a = m ? alpha(a, *m++, dest->alpha) : alpha(a, dest->alpha);
 
       if (a >= 255) {
         *d++ = pen->r; *d++ = pen->g; *d++ = pen->b;

--- a/32blit/graphics/blend.cpp
+++ b/32blit/graphics/blend.cpp
@@ -3,14 +3,14 @@
 
 #include "surface.hpp"
 
-#ifdef WIN32 
+#ifdef WIN32
 #define __attribute__(A)
 #endif
 
 // note:
-// for performance reasons none of the blending functions make any attempt 
-// to validate input, adhere to clipping, or source/destination bounds. it 
-// is assumed that all validation has been done by the caller. 
+// for performance reasons none of the blending functions make any attempt
+// to validate input, adhere to clipping, or source/destination bounds. it
+// is assumed that all validation has been done by the caller.
 
 namespace blit {
 
@@ -23,11 +23,11 @@ namespace blit {
   }
 
   __attribute__((always_inline)) inline uint8_t blend(uint8_t s, uint8_t d, uint8_t a) {
-    return d + ((a * (s - d) + 127) >> 8);    
+    return d + ((a * (s - d) + 127) >> 8);
   }
 
-  __attribute__((always_inline)) inline void blend_rgba_rgb(const Pen *s, uint8_t *d, uint8_t a, uint32_t c) {      
-    if (c == 1) { 
+  __attribute__((always_inline)) inline void blend_rgba_rgb(const Pen *s, uint8_t *d, uint8_t a, uint32_t c) {
+    if (c == 1) {
       // fast case for single pixel draw
       *d = blend(s->r, *d, a); d++;
       *d = blend(s->g, *d, a); d++;
@@ -58,9 +58,9 @@ namespace blit {
       // rotate the aligned rgbr/gbrg/brgb quad
       s32 >>= 8; s32 |= uint8_t(s32 & 0xff) << 24;
     }
-        
+
     // destination is now double-word aligned
-    if (d < de) {      
+    if (d < de) {
       // get a double-word aligned pointer to the destination surface
       uint32_t *d32 = (uint32_t*)d;
 
@@ -69,12 +69,12 @@ namespace blit {
       while (c32--) {
         uint32_t dd32 = *d32;
 
-        *d32++ = blend((s32 & 0xff), (dd32 & 0xff), a) | 
-                (blend((s32 & 0xff00) >> 8, (dd32 & 0xff00) >> 8, a) << 8) | 
+        *d32++ = blend((s32 & 0xff), (dd32 & 0xff), a) |
+                (blend((s32 & 0xff00) >> 8, (dd32 & 0xff00) >> 8, a) << 8) |
                 (blend((s32 & 0xff0000) >> 16, (dd32 & 0xff0000) >> 16, a) << 16) |
                 (blend((s32 & 0xff000000) >> 24, (dd32 & 0xff000000) >> 24, a) << 24);
 
-        // rotate the aligned rgbr/gbrg/brgb quad        
+        // rotate the aligned rgbr/gbrg/brgb quad
         s32 >>= 8; s32 |= uint8_t(s32 & 0xff) << 24;
       }
 
@@ -87,19 +87,19 @@ namespace blit {
   }
 
   __attribute__((always_inline)) inline void copy_rgba_rgb(const Pen* s, uint8_t *d, uint32_t c) {
-    if (c == 1) { 
+    if (c == 1) {
       // fast case for single pixel draw
-      *(d + 0) = s->r; *(d + 1) = s->g; *(d + 2) = s->b; 
+      *(d + 0) = s->r; *(d + 1) = s->g; *(d + 2) = s->b;
       return;
     }
-    
+
     if (c <= 4) {
       // fast case for small number of pixels
       do {
         *(d + 0) = s->r; *(d + 1) = s->g; *(d + 2) = s->b; d += 3;
-      } while (--c);      
+      } while (--c);
       return;
-    }    
+    }
 
     // create packed 32bit source
     // s32 now contains RGBA
@@ -114,9 +114,9 @@ namespace blit {
       // rotate the aligned rgbr/gbrg/brgb quad
       s32 >>= 8; s32 |= uint8_t(s32 & 0xff) << 24;
     }
-        
+
     // destination is now double-word aligned
-    if (d < de) {      
+    if (d < de) {
       // get a double-word aligned pointer to the destination surface
       uint32_t *d32 = (uint32_t*)d;
 
@@ -124,7 +124,7 @@ namespace blit {
       uint32_t c32 = uint32_t(de - d) >> 2;
       while (c32--) {
         *d32++ = s32;
-        // rotate the aligned rgbr/gbrg/brgb quad        
+        // rotate the aligned rgbr/gbrg/brgb quad
         s32 >>= 8; s32 |= uint8_t(s32 & 0xff) << 24;
       }
 
@@ -138,7 +138,7 @@ namespace blit {
 
   void RGBA_RGBA(const Pen* pen, const Surface* dest, uint32_t off, uint32_t cnt) {
     uint8_t* d = dest->data + (off * 4);
-    uint8_t* m = dest->mask ? dest->mask->data + off : nullptr;    
+    uint8_t* m = dest->mask ? dest->mask->data + off : nullptr;
 
     uint16_t a1 = alpha(pen->a, dest->alpha);
     do {
@@ -159,8 +159,8 @@ namespace blit {
 
   void RGBA_RGB(const Pen* pen, const Surface* dest, uint32_t off, uint32_t c) {
     uint8_t* d = dest->data + (off * 3);
-    uint8_t* m = dest->mask ? dest->mask->data + off : nullptr;    
-  
+    uint8_t* m = dest->mask ? dest->mask->data + off : nullptr;
+
     uint16_t a = alpha(pen->a, dest->alpha);
     if (!m) {
       // no mask
@@ -205,7 +205,7 @@ namespace blit {
   void RGBA_RGBA(const Surface* src, uint32_t soff, const Surface* dest, uint32_t doff, uint32_t cnt, int32_t src_step) {
     uint8_t* s = src->palette ? src->data + soff : src->data + (soff * src->pixel_stride);
     uint8_t* d = dest->data + (doff * 3);
-    uint8_t* m = dest->mask ? dest->mask->data + doff : nullptr;    
+    uint8_t* m = dest->mask ? dest->mask->data + doff : nullptr;
 
     do {
       Pen *pen = src->palette ? &src->palette[*s] : (Pen *)s;
@@ -222,7 +222,7 @@ namespace blit {
         *d = blend(pen->b, *d, a); d++;
       }else{
         d += 4;
-      }       
+      }
 
       s += src->pixel_stride * src_step;
     } while (--cnt);
@@ -231,7 +231,25 @@ namespace blit {
   void RGBA_RGB(const Surface* src, uint32_t soff, const Surface* dest, uint32_t doff, uint32_t cnt, int32_t src_step) {
     uint8_t* s = src->palette ? src->data + soff : src->data + (soff * src->pixel_stride);
     uint8_t* d = dest->data + (doff * 3);
-    uint8_t* m = dest->mask ? dest->mask->data + doff : nullptr;    
+    uint8_t* m = dest->mask ? dest->mask->data + doff : nullptr;
+
+    // solid fill/blend
+    if(!m && src_step == 0 && cnt > 1) {
+      Pen *pen = src->palette ? &src->palette[*s] : (Pen *)s;
+
+      uint16_t a = src->format == PixelFormat::RGB ? 0 : pen->a;
+      a = alpha(a, dest->alpha);
+
+      if (a >= 255) {
+        // no alpha, just copy
+        copy_rgba_rgb(pen, d, cnt);
+      }
+      else {
+        // alpha, blend
+        blend_rgba_rgb(pen, d, a, cnt);
+      }
+      return;
+    }
 
     do {
       Pen *pen = src->palette ? &src->palette[*s] : (Pen *)s;
@@ -247,7 +265,7 @@ namespace blit {
         *d = blend(pen->b, *d, a); d++;
       }else{
         d += 3;
-      }       
+      }
 
       s += (src->pixel_stride) * src_step;
     } while (--cnt);

--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -207,7 +207,7 @@ namespace blit {
         wc += dwc;
         doff++;
         c--;
-      } while(c && (wc.x >> fix_shift + 3) == wcx >> 3 && (wc.y >> fix_shift + 3) == wcy >> 3);
+      } while(c && (wc.x >> (fix_shift + 3)) == wcx >> 3 && (wc.y >> (fix_shift + 3)) == wcy >> 3);
 
     } while (c);
   }

--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -24,8 +24,8 @@ namespace blit {
    * TODO: Document
    */
   int32_t TileMap::offset(const Point &p) {
-    int32_t cx = ((uint16_t)p.x) & (bounds.w - 1);
-    int32_t cy = ((uint16_t)p.y) & (bounds.h - 1);
+    int32_t cx = ((uint32_t)p.x) & (bounds.w - 1);
+    int32_t cy = ((uint32_t)p.y) & (bounds.h - 1);
 
     if ((p.x ^ cx) | (p.y ^ cy)) {
       if (repeat_mode == DEFAULT_FILL)
@@ -47,8 +47,8 @@ namespace blit {
    * \param[in] y
    */
   int32_t TileMap::offset(int16_t x, int16_t y) {
-    int32_t cx = ((uint16_t)x) & (bounds.w - 1);
-    int32_t cy = ((uint16_t)y) & (bounds.h - 1);
+    int32_t cx = ((uint32_t)x) & (bounds.w - 1);
+    int32_t cy = ((uint32_t)y) & (bounds.h - 1);
 
     if ((x ^ cx) | (y ^ cy)) {
       if (repeat_mode == DEFAULT_FILL)
@@ -168,14 +168,14 @@ namespace blit {
         uint8_t transform = transforms[toff];
 
         // coordinate within sprite
-        uint8_t u = wcx & 0b111;
-        uint8_t v = wcy & 0b111;
+        int u = wcx & 0b111;
+        int v = wcy & 0b111;
 
         // if this tile has a transform then modify the uv coordinates
         if (transform) {
           v = (transform & 0b010) ? (7 - v) : v;
           u = (transform & 0b100) ? (7 - u) : u;
-          if (transform & 0b001) { uint8_t tmp = u; u = v; v = tmp; }
+          if (transform & 0b001) { int tmp = u; u = v; v = tmp; }
         }
 
         // sprite sheet coordinates for top left corner of sprite

--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -7,7 +7,7 @@ namespace blit {
 
   /**
    * Create a new tilemap.
-   * 
+   *
    * \param[in] tiles
    * \param[in] transforms
    * \param[in] bounds Map bounds, must be a power of two
@@ -42,7 +42,7 @@ namespace blit {
 
   /**
    * TODO: Document
-   * 
+   *
    * \param[in] x
    * \param[in] y
    */
@@ -144,22 +144,25 @@ namespace blit {
 
   /**
    * TODO: Document
-   * 
+   *
    * \param[in] dest
    * \param[in] s
    * \param[in] c
    * \param[in] swc
    * \param[in] ewc
    */
-  void TileMap::texture_span(Surface *dest, Point s, uint16_t c, Vec2 swc, Vec2 ewc) {
+  void TileMap::texture_span(Surface *dest, Point s, unsigned int c, Vec2 swc, Vec2 ewc) {
     Surface *src = sprites;
 
-    Vec2 wc = swc;
-    Vec2 dwc = (ewc - swc) / float(c);
+    static const int fix_shift = 16;
+
+    Point wc(swc * (1 << fix_shift));
+    Point dwc(((ewc - swc) / float(c)) * (1 << fix_shift));
     int32_t doff = dest->offset(s.x, s.y);
+
     do {
-      int16_t wcx = floorf(wc.x);
-      int16_t wcy = floorf(wc.y);
+      int16_t wcx = wc.x >> fix_shift;
+      int16_t wcy = wc.y >> fix_shift;
 
       int32_t toff = offset(wcx >> 3, wcy >> 3);
 
@@ -182,12 +185,31 @@ namespace blit {
         u += (tile_id & 0b1111) * 8;
         v += (tile_id >> 4) * 8;
 
-        dest->bbf(src, src->offset(u, v), dest, doff, 1, 1);
+        // draw as many pixels as possible
+        int count = 0;
+
+        do {
+          wc += dwc;
+          c--;
+          count++;
+        } while(c && (wc.x >> fix_shift) == wcx && (wc.y >> fix_shift) == wcy);
+
+        int soff = src->offset(u, v);
+        dest->bbf(src, soff, dest, doff, count, 0);
+
+        doff += count;
+
+        continue;
       }
 
-      wc += dwc;
-      doff++;
-    } while (--c);
+      // skip to next tile
+      do {
+        wc += dwc;
+        doff++;
+        c--;
+      } while(c && (wc.x >> fix_shift + 3) == wcx >> 3 && (wc.y >> fix_shift + 3) == wcy >> 3);
+
+    } while (c);
   }
 
 }

--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -163,7 +163,7 @@ namespace blit {
 
       int32_t toff = offset(wcx >> 3, wcy >> 3);
 
-      if (toff != -1) {
+      if (toff != -1 && tiles[toff] != empty_tile_id) {
         uint8_t tile_id = tiles[toff];
         uint8_t transform = transforms[toff];
 

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -26,6 +26,8 @@ namespace blit {
     } repeat_mode;        // determines what to do when drawing outside of the layer bounds.
     uint8_t       default_tile_id;
 
+    int empty_tile_id = -1;
+
     TileMap(uint8_t *tiles, uint8_t *transforms, Size bounds, Surface *sprites);
 
     inline int32_t offset(const Point &p); // __attribute__((always_inline));

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -38,7 +38,7 @@ namespace blit {
     void draw(Surface *dest, Rect viewport, std::function<Mat3(uint8_t)> scanline_callback = nullptr);
 
   //  void mipmap_texture_span(surface *dest, point s, uint16_t c, vec2 swc, vec2 ewc);
-    void texture_span(Surface *dest, Point s, uint16_t c, Vec2 swc, Vec2 ewc);
+    void texture_span(Surface *dest, Point s, unsigned int c, Vec2 swc, Vec2 ewc);
   };
 
 }


### PR DESCRIPTION
Reduces "Super Blit Kart" `render` times by 8ms and makes the track rendering > 2.5x faster. First commit also means you can put something in the tile index you have defined as empty for other uses.

(I also have some patches for sprite stretch blits, but I think those need more work/testing)