### PR TITLE
MP3 looping and restart/play from start

### DIFF
--- a/32blit/audio/mp3-stream.cpp
+++ b/32blit/audio/mp3-stream.cpp
@@ -79,6 +79,26 @@ namespace blit {
     blit::channels[channel].off();
   }
 
+  void MP3Stream::restart() {
+    bool was_playing = get_playing();
+    pause();
+
+    // reset file buffer
+    file_buffer_filled = 0;
+    file_offset = 0;
+    read(0);
+
+    // reset sample buffer
+    current_sample = nullptr;
+    buffered_samples = 0;
+
+    // re-init decoder
+    mp3dec_init(static_cast<mp3dec_t *>(mp3dec));
+
+    if(was_playing)
+      play(channel);
+  }
+
   bool MP3Stream::get_playing() const {
     return channel != -1 && blit::channels[channel].adsr_phase == blit::ADSRPhase::SUSTAIN;
   }

--- a/32blit/audio/mp3-stream.cpp
+++ b/32blit/audio/mp3-stream.cpp
@@ -51,11 +51,17 @@ namespace blit {
     return true;
   }
 
-  void MP3Stream::play(int channel) {
+  void MP3Stream::play(int channel, int flags) {
     if(!file_buffer_filled)
       return;
 
+    pause();
+
     this->channel = channel;
+    this->play_flags = flags;
+
+    if((flags & PlayFlags::from_start) && buffered_samples)
+      restart();
 
     if(!current_sample) {
       decode(0);
@@ -96,11 +102,15 @@ namespace blit {
     mp3dec_init(static_cast<mp3dec_t *>(mp3dec));
 
     if(was_playing)
-      play(channel);
+      play(channel, play_flags);
   }
 
   bool MP3Stream::get_playing() const {
     return channel != -1 && blit::channels[channel].adsr_phase == blit::ADSRPhase::SUSTAIN;
+  }
+
+  int MP3Stream::get_play_flags() const {
+    return play_flags;
   }
 
   void MP3Stream::update() {
@@ -165,7 +175,17 @@ namespace blit {
     } while (samples + (MINIMP3_MAX_SAMPLES_PER_FRAME / (2 * freq_scale)) <= audio_buf_size);
 
     if(!samples) {
-      data_size[buf_index] = -1;
+      if(play_flags & PlayFlags::loop) {
+        // back to start
+        file_buffer_filled = 0;
+        file_offset = 0;
+        read(0);
+
+        mp3dec_init(static_cast<mp3dec_t *>(mp3dec));
+        decode(buf_index);
+      } else
+        data_size[buf_index] = -1;
+
       return;
     }
 

--- a/32blit/audio/mp3-stream.hpp
+++ b/32blit/audio/mp3-stream.hpp
@@ -6,19 +6,26 @@
 #include "engine/file.hpp"
 
 namespace blit {
-  class MP3Stream final
-  {
+
+  class MP3Stream final {
   public:
+
+    enum PlayFlags {
+      from_start = (1 << 0),
+      loop       = (1 << 1)
+    };
+
     MP3Stream();
     ~MP3Stream();
 
     bool load(std::string filename, bool do_duration_calc = false);
 
-    void play(int channel);
+    void play(int channel, int flags = 0);
     void pause();
     void restart();
 
     bool get_playing() const;
+    int get_play_flags() const;
 
     void update();
 
@@ -43,6 +50,7 @@ namespace blit {
     int32_t file_buffer_filled = 0;
 
     int channel = -1;
+    int play_flags = 0;
 
     // decoding
     void *mp3dec = nullptr;

--- a/32blit/audio/mp3-stream.hpp
+++ b/32blit/audio/mp3-stream.hpp
@@ -16,6 +16,7 @@ namespace blit {
 
     void play(int channel);
     void pause();
+    void restart();
 
     bool get_playing() const;
 

--- a/examples/mp3/mp3.cpp
+++ b/examples/mp3/mp3.cpp
@@ -56,5 +56,14 @@ void render(uint32_t time) {
 }
 
 void update(uint32_t time) {
+
+  // play/pause
+  if(buttons.released & Button::A) {
+    if(stream.get_playing())
+      stream.pause();
+    else
+      stream.play(0);
+  }
+
   stream.update();
 }

--- a/examples/mp3/mp3.cpp
+++ b/examples/mp3/mp3.cpp
@@ -65,5 +65,9 @@ void update(uint32_t time) {
       stream.play(0);
   }
 
+  // restart
+  if(buttons.released & Button::X)
+    stream.restart();
+
   stream.update();
 }


### PR DESCRIPTION
Adds a `restart` method to `MP3Stream` (resets decoder to start) and `loop`/`from_start` flags to `play`.