### PR TITLE
Minor SDL multiplayer fixes

### DIFF
--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -23,6 +23,9 @@ Multiplayer::~Multiplayer() {
 }
 
 void Multiplayer::update() {
+    if(!enabled)
+        return;
+  
     if(!socket && !listen_socket) {
         // attempt to reconnect
         auto now = SDL_GetTicks();

--- a/32blit-sdl/Multiplayer.cpp
+++ b/32blit-sdl/Multiplayer.cpp
@@ -191,21 +191,18 @@ void Multiplayer::setup() {
     // try connecting first for auto
     if(mode != Mode::Listen) {
         if(SDLNet_ResolveHost(&ip, address.c_str(), port) == -1) {
-            std::cerr << "Failed to resolve host: " << SDLNet_GetError() << std::endl;
-            return;
-        }
-
-        socket = SDLNet_TCP_Open(&ip);
+            std::cerr << "Failed to resolve \"" << address << "\"!" << std::endl;
+        } else
+            socket = SDLNet_TCP_Open(&ip);
     }
 
     if(!socket && mode != Mode::Connect) {
         // try hosting instead unless connecting was specified
         if(SDLNet_ResolveHost(&ip, nullptr, port) == -1) {
-            std::cerr << "Failed to resolve host: " << SDLNet_GetError() << std::endl;
-            return;
-        }
-
-        listen_socket = SDLNet_TCP_Open(&ip);
+            // this can't fail
+            std::cerr << "Failed to resolve \"any\" address!" << std::endl;
+        } else
+            listen_socket = SDLNet_TCP_Open(&ip);
     }
 
     if(!socket && !listen_socket) {


### PR DESCRIPTION
... the one thing I didn't test with the last multiplayer PR was _not_ using multiplayer. This should stop the SDL code from attempting to (re-)connect even if multiplayer is disabled. Also improves a bit of the error handling.