### PR TITLE
Add a wrapper for the microsecond timer

### DIFF
--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -27,6 +27,17 @@ namespace blit {
     return api.now();
   }
 
+  uint32_t now_us() {
+    return api.get_us_timer();
+  }
+
+  uint32_t us_diff(uint32_t from, uint32_t to) {
+    if(to >= from)
+      return to - from;
+    else // wrap
+      return (api.get_max_us_timer() - from) + to;
+  }
+
   uint32_t random() {
     return api.random();
   }

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -19,6 +19,9 @@ namespace blit {
   void set_screen_palette(const Pen *colours, int num_cols);
 
   uint32_t now();
+  uint32_t now_us();
+  uint32_t us_diff(uint32_t from, uint32_t to);
+
   uint32_t random();
 
   void debug(std::string message);


### PR DESCRIPTION
I keep `#include`-ing api_private.hpp to use `get_us_timer` for profiling. This adds a `blit::now_us` wrapper for when you just want to time one thing precisely without setting up the profiler.




(Sometimes isn't any more precise than a millisecond... *looks at Emscripten/Firefox*)