### PR TITLE
Waste less memory on buffers in MP3Stream

### DIFF
--- a/32blit/audio/mp3-stream.hpp
+++ b/32blit/audio/mp3-stream.hpp
@@ -46,7 +46,7 @@ namespace blit {
     uint32_t file_offset = 0;
 
     static const int file_buffer_size = 1024 * 4;
-    uint8_t file_buffer[file_buffer_size];
+    uint8_t *file_buffer = nullptr;
     int32_t file_buffer_filled = 0;
 
     int channel = -1;

--- a/32blit/audio/mp3-stream.hpp
+++ b/32blit/audio/mp3-stream.hpp
@@ -56,7 +56,7 @@ namespace blit {
     void *mp3dec = nullptr;
     bool need_convert = false;
 
-    static const int audio_buf_size = 1152 * 4;
+    static const int audio_buf_size = 1152;
     int16_t audio_buf[2][audio_buf_size];
     int16_t *current_sample = nullptr, *end_sample = nullptr;
     int data_size[2]{};


### PR DESCRIPTION
~22k -> ~4.7k.

Avoid the file buffer if unneeded (buffer files) and reduce the size of the output buffer (can't remember why it was so big).

Just need to test more on device...