### PR TITLE
Some MP3 buffering fixes

### DIFF
--- a/32blit/audio/mp3-stream.cpp
+++ b/32blit/audio/mp3-stream.cpp
@@ -92,7 +92,8 @@ namespace blit {
   }
 
   void MP3Stream::pause() {
-    blit::channels[channel].off();
+    if(channel != -1)
+      blit::channels[channel].off();
   }
 
   void MP3Stream::restart() {

--- a/32blit/audio/mp3-stream.cpp
+++ b/32blit/audio/mp3-stream.cpp
@@ -214,7 +214,11 @@ namespace blit {
 
     // there was no buffer last time
     if(current_sample == end_sample) {
-      if(data_size[cur_audio_buf]) {
+      if(data_size[cur_audio_buf] == -1) {
+        current_sample = end_sample = nullptr;
+        channel.off();
+        return;
+      } else if(data_size[cur_audio_buf]) {
         end_sample = audio_buf[cur_audio_buf] + data_size[cur_audio_buf]; // recovered from underrun
       } else {
         memset(channel.wave_buffer, 0, 64 * sizeof(int16_t));


### PR DESCRIPTION
Smaller buffer exposed some existing bugs. Fixes an underrun right at the end of the file preventing the end from being detected and the decode loop using the worst-case output size instead of calculating it, resulting in half-filled buffers most of the time.

(Guess that was why the buffers were so big...)