### PR TITLE
Ignore API versioning in the firmware updater

### DIFF
--- a/32blit-stm32/startup_user.cpp
+++ b/32blit-stm32/startup_user.cpp
@@ -6,11 +6,13 @@ extern void update(uint32_t time);
 extern void render(uint32_t time);
 
 extern "C" bool cpp_do_init() {
+#ifndef IGNORE_API_VERSION
   if(blit::api.version_major != blit::api_version_major)
     return false;
 
   if(blit::api.version_minor < blit::api_version_minor)
     return false;
+#endif
 
   blit::update = update;
   blit::render = render;

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -19,3 +19,4 @@ configure_file(metadata.yml.in metadata.yml)
 blit_metadata(firmware-update ${CMAKE_CURRENT_BINARY_DIR}/metadata.yml)
 
 target_include_directories(firmware-update PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_compile_definitions(firmware-update PRIVATE IGNORE_API_VERSION)


### PR DESCRIPTION
Because of the bug in <0.1.11 where the API version was uninitialised, the latest firmware updater doesn't run... unless you already have that firmware. (Also makes sense for any future unavoidable breaking changes.)

The updater doesn't even use almost all of the API anyway. (`buttons` from `blit::tick` and `set_screen_mode` from the init code. `set_screen_mode` is also the first function)

Tested that this runs all the way back to v0.1.2 (first version with .blit). (Excluding any other issues, like the one that deletes the updater)