### PR TITLE
Made offset(Point) callable, reduced function redundancy!

### DIFF
--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -46,26 +46,6 @@ namespace blit {
 
   /**
    * TODO: Document
-   */
-  int32_t TileMap::offset(const Point &p) {
-    int32_t cx = ((uint32_t)p.x) & (bounds.w - 1);
-    int32_t cy = ((uint32_t)p.y) & (bounds.h - 1);
-
-    if ((p.x ^ cx) | (p.y ^ cy)) {
-      if (repeat_mode == DEFAULT_FILL)
-        return default_tile_id;
-
-      if (repeat_mode == REPEAT)
-        return cx + cy * bounds.w;
-
-      return -1;
-    }
-
-    return cx + cy * bounds.w;
-  }
-
-  /**
-   * TODO: Document
    *
    * \param[in] x
    * \param[in] y
@@ -94,7 +74,7 @@ namespace blit {
    * \return Bitmask of flags for specified tile.
    */
   uint8_t TileMap::tile_at(const Point &p) {
-    int32_t o = offset(p);
+    int32_t o = offset(p.x, p.y);
 
     if(o != -1)
       return tiles[o];
@@ -109,7 +89,7 @@ namespace blit {
    * \return Bitmask of transforms for specified tile.
    */
   uint8_t TileMap::transform_at(const Point &p) {
-    int32_t o = offset(p);
+    int32_t o = offset(p.x, p.y);
 
     if (o != -1 && transforms)
       return transforms[o];

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -49,7 +49,7 @@ namespace blit {
 
     static TileMap *load_tmx(const uint8_t *asset, Surface *sprites, int layer = 0, int flags = copy_tiles);
 
-    inline int32_t offset(const Point &p); // __attribute__((always_inline));
+    inline int32_t offset(const Point &p) {return offset(p.x, p.y);} // __attribute__((always_inline));
     int32_t offset(int16_t x, int16_t y); // __attribute__((always_inline));
     uint8_t tile_at(const Point &p); // __attribute__((always_inline));
     uint8_t transform_at(const Point &p); // __attribute__((always_inline));


### PR DESCRIPTION
Now have only one implementation of offset(), and the version that takes a blit::Point is actually callable.