### PR TITLE
Add a CLAMP_TO_EDGE repeat mode to TileMap

### DIFF
--- a/32blit/graphics/tilemap.cpp
+++ b/32blit/graphics/tilemap.cpp
@@ -61,6 +61,15 @@ namespace blit {
       if (repeat_mode == REPEAT)
         return cx + cy * bounds.w;
 
+      if(repeat_mode == CLAMP_TO_EDGE) {
+        if(x != cx)
+          cx = x < 0 ? 0 : bounds.w - 1;
+        if(y != cy)
+          cy = y < 0 ? 0 : bounds.h - 1;
+
+        return cx + cy * bounds.w;
+      }
+
       return -1;
     }
 

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -37,7 +37,7 @@ namespace blit {
       REPEAT = 1,         // infinite repeat
       DEFAULT_FILL = 2,   // fill with default tile
       CLAMP_TO_EDGE = 3,  // repeats the tile at the edge
-    } repeat_mode;        // determines what to do when drawing outside of the layer bounds.
+    } repeat_mode = NONE; // determines what to do when drawing outside of the layer bounds.
     uint8_t       default_tile_id;
 
     int empty_tile_id = -1;

--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -35,7 +35,8 @@ namespace blit {
     enum {
       NONE = 0,           // draw nothing
       REPEAT = 1,         // infinite repeat
-      DEFAULT_FILL = 2    // fill with default tile
+      DEFAULT_FILL = 2,   // fill with default tile
+      CLAMP_TO_EDGE = 3,  // repeats the tile at the edge
     } repeat_mode;        // determines what to do when drawing outside of the layer bounds.
     uint8_t       default_tile_id;
 


### PR DESCRIPTION
Clamps to the tile at the edge of the map. Almost called it `CLAMP` but `NONE`/`DEFAULT_FILL` also clamp (hmm, kind of like `CLAMP_TO_BORDER` in most graphics APIs).

Though while doing this, noticed that `DEFAULT_FILL` doesn't do what I expected it to do (`default_tile_id` is an index into the map instead of the tileset...)


Also, enum case inconsistency...