### PR TITLE
Disable sound when the menu is open

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -467,13 +467,15 @@ void blit_menu() {
       blit::render = ::render;
     }
 
+    if(!user_code_disabled)
+      sound::enabled = true;
+
     // restore game colours
     if(screen.format == PixelFormat::P) {
       set_screen_palette(menu_saved_colours, num_menu_colours);
     }
-  }
-  else
-  {
+  } else {
+    sound::enabled = false;
     system_menu.prepare();
 
     blit::update = blit_menu_update;


### PR DESCRIPTION
Since `update` isn't getting called you end up with broken audio most of the time (unless you're streaming entirely in the callback). I _think_ this shouldn't break the other user of `sound::enabled` ("user code" disabling for flash stuff)