### PR TITLE
Added --launch_path option to SDL builds

### DIFF
--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -32,6 +32,8 @@ Multiplayer *blit_multiplayer;
 Renderer *blit_renderer;
 Audio *blit_audio;
 
+const char *launch_path = nullptr;
+
 #ifdef VIDEO_CAPTURE
 VideoCapture *blit_capture;
 unsigned int last_record_startstop = 0;
@@ -158,6 +160,9 @@ int main(int argc, char *argv[]) {
 			mp_address = std::string(argv[i + 1]);
 			i++;
 		}
+		else if(arg_str == "--launch_path" && i + 1 < argc) {
+			launch_path = argv[++i];
+		}
 		else if(arg_str == "--listen")
 			mp_mode = Multiplayer::Mode::Listen;
 		else if(arg_str == "--position") {
@@ -195,11 +200,12 @@ int main(int argc, char *argv[]) {
 		}
 		else if(arg_str == "--help") {
 			std::cout << "Usage: " << argv[0] << " <options>" << std::endl << std::endl;
-			std::cout << " --connect <addr> -- Connect to a listening game instance." << std::endl;
-			std::cout << " --listen         -- Listen for incoming connections." << std::endl;
-			std::cout << " --position x,y   -- Set window position." << std::endl;
-			std::cout << " --credits        -- Print contributor credits and exit." << std::endl;
-			std::cout << " --info           -- Print metadata info and exit." << std::endl << std::endl;
+			std::cout << " --connect <addr>     -- Connect to a listening game instance." << std::endl;
+			std::cout << " --listen             -- Listen for incoming connections." << std::endl;
+			std::cout << " --position x,y       -- Set window position." << std::endl;
+			std::cout << " --launch_path <file> -- Emulates the file associations on the console." << std::endl;
+			std::cout << " --credits            -- Print contributor credits and exit." << std::endl;
+			std::cout << " --info               -- Print metadata info and exit." << std::endl << std::endl;
 			SDL_DestroyWindow(window);
 			SDL_Quit();
 			return 0;

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -90,6 +90,8 @@ uint32_t get_max_us_timer()
 	return UINT32_MAX;
 }
 
+/* Added a command line ability to specify a launch_path parameter. */
+extern const char *launch_path;
 static const char *get_launch_path() {
   return launch_path;
 }

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -91,7 +91,7 @@ uint32_t get_max_us_timer()
 }
 
 static const char *get_launch_path() {
-  return nullptr; // TODO: argv[1]
+  return launch_path;
 }
 
 static blit::GameMetadata get_metadata() {

--- a/32blit-sdl/UserCode.hpp
+++ b/32blit-sdl/UserCode.hpp
@@ -11,3 +11,6 @@ extern const char *metadata_description;
 extern const char *metadata_version;
 extern const char *metadata_url;
 extern const char *metadata_category;
+
+/* Added a command line ability to specify a launch_path parameter. */
+extern const char *launch_path;

--- a/32blit-sdl/UserCode.hpp
+++ b/32blit-sdl/UserCode.hpp
@@ -11,6 +11,3 @@ extern const char *metadata_description;
 extern const char *metadata_version;
 extern const char *metadata_url;
 extern const char *metadata_category;
-
-/* Added a command line ability to specify a launch_path parameter. */
-extern const char *launch_path;


### PR DESCRIPTION
Added a command line option to SDL builds to make it easier to test Blits that handle file associations; returns the provided file from the `get_launch_path()` function as it does when launching an associated file on the 32blit itself.

TL;DR - saw the `// TODO` comment, and did :-)