### PR TITLE
Don't trim whitespace from patches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ cpp_new_line_before_open_brace_type = same_line
 cpp_new_line_before_open_brace_function = same_line
 cpp_new_line_before_open_brace_class = same_line
 cpp_new_line_before_open_brace_block = same_line
+
+[*.{diff,patch}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Corrupting patches when you save them is more than a little annoying. Especially when you're using  `git add –patch` and trying to edit...