### PR TITLE
Mostly cleanup patches

### DIFF
--- a/32blit-stm32/Inc/32blit.h
+++ b/32blit-stm32/Inc/32blit.h
@@ -11,39 +11,39 @@
 extern bool is_beta_unit;
 
 // Functions defined by user code files
-extern void init();
-extern void update(uint32_t time);
-extern void render(uint32_t time);
+void init();
+void update(uint32_t time);
+void render(uint32_t time);
 
 // SD storage
-extern char *get_fr_err_text(FRESULT err);
-extern bool blit_sd_detected();
-extern bool blit_sd_mounted();
+char *get_fr_err_text(FRESULT err);
+bool blit_sd_detected();
+bool blit_sd_mounted();
 
-extern void render_yield();
+void render_yield();
 
 // Blit setup and main loop
-extern void blit_tick();
-extern void blit_init();
+void blit_tick();
+void blit_init();
 
 // IO
 void blit_update_volume();
-extern void blit_update_vibration();
-extern void blit_update_led();
-extern void blit_process_input();
+void blit_update_vibration();
+void blit_update_led();
+void blit_process_input();
 
 // Switching execution.
 // Address is relative to the start of flash, ignored if switching to firmware
-extern bool blit_switch_execution(uint32_t address, bool force_game);
-extern bool blit_user_code_running();
+bool blit_switch_execution(uint32_t address, bool force_game);
+bool blit_user_code_running();
 extern "C" void blit_reset_with_error();
-extern void blit_enable_user_code();
-extern void blit_disable_user_code();
-extern RawMetadata *blit_get_running_game_metadata();
+void blit_enable_user_code();
+void blit_disable_user_code();
+RawMetadata *blit_get_running_game_metadata();
 
 void blit_menu_update(uint32_t time);
 void blit_menu_render(uint32_t time);
 void blit_menu();
 
-extern void blit_enable_ADC();
-extern void blit_disable_ADC();
+void blit_enable_ADC();
+void blit_disable_ADC();

--- a/32blit-stm32/Inc/32blit.h
+++ b/32blit-stm32/Inc/32blit.h
@@ -27,6 +27,7 @@ extern void blit_tick();
 extern void blit_init();
 
 // IO
+void blit_update_volume();
 extern void blit_update_vibration();
 extern void blit_update_led();
 extern void blit_process_input();

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -313,6 +313,11 @@ void blit_init() {
       persist.reset_error = false;
       persist.last_game_offset = 0;
       memset(persist.launch_path, 0, sizeof(persist.launch_path));
+
+      // clear LTDC buffer to avoid flash of uninitialised data
+      extern char __ltdc_start;
+      int len = 320 * 240 * 2;
+      memset(&__ltdc_start, 0, len);
     }
 
 #if (INITIALISE_QSPI==1)

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -75,7 +75,6 @@ static bool (*user_tick)(uint32_t time) = nullptr;
 static void (*user_render)(uint32_t time) = nullptr;
 static bool user_code_disabled = false;
 
-void blit_update_volume();
 static void update_active();
 
 void DFUBoot(void)

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -607,8 +607,6 @@ void blit_enable_ADC()
 }
 
 void blit_process_input() {
-  bool joystick_button = false;
-
   // Read buttons
   blit::buttons =
     (!HAL_GPIO_ReadPin(DPAD_UP_GPIO_Port,     DPAD_UP_Pin)      ? blit::DPAD_UP    : 0) |
@@ -758,8 +756,6 @@ bool blit_switch_execution(uint32_t address, bool force_game)
   HAL_NVIC_DisableIRQ(OTG_HS_IRQn);
   HAL_NVIC_DisableIRQ(EXTI9_5_IRQn);
   HAL_NVIC_DisableIRQ(TIM2_IRQn);
-
-	volatile uint32_t uAddr = EXTERNAL_LOAD_ADDRESS;
 
 	/* Disable I-Cache */
 	SCB_DisableICache();

--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -219,9 +219,6 @@ uint8_t	*CDCCommandStream::GetFifoWriteBuffer(void)
 	else
 		m_bNeedsUSBResume = true;
 
-	if(!pData)
-		volatile int bp = 1;
-
 	return pData;
 }
 

--- a/32blit-stm32/Src/SystemMenu/about_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/about_menu.cpp
@@ -40,11 +40,6 @@ void AboutMenu::render_item(const Item &item, int y, int index) const {
 
   const auto screen_width = screen.bounds.w;
 
-  const int bar_margin = 2;
-  const int bar_height = item_h - bar_margin * 2;
-  const int bar_width = 75;
-  int bar_x = screen_width - bar_width - item_padding_x;
-
   switch (item.id) {
   case FIRMWARE_VERSION:
     screen.text(get_version_string(), minimal_font, Point(screen_width - item_padding_x, y + 1), true, TextAlign::right);

--- a/32blit-stm32/Src/SystemMenu/battery_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/battery_menu.cpp
@@ -36,11 +36,6 @@ void BatteryMenu::render_item(const Item &item, int y, int index) const {
 
   const auto screen_width = screen.bounds.w;
 
-  const int bar_margin = 2;
-  const int bar_height = item_h - bar_margin * 2;
-  const int bar_width = 75;
-  int bar_x = screen_width - bar_width - item_padding_x;
-
   BatteryInformation bat = battery::get_info();
 
   switch (item.id) {

--- a/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
@@ -39,11 +39,6 @@ void ConnectivityMenu::render_item(const Item &item, int y, int index) const {
 
   const auto screen_width = screen.bounds.w;
 
-  const int bar_margin = 2;
-  const int bar_height = item_h - bar_margin * 2;
-  const int bar_width = 75;
-  int bar_x = screen_width - bar_width - item_padding_x;
-
   switch (item.id) {
   case STORAGE:
     screen.pen = foreground_colour;

--- a/32blit-stm32/Src/SystemMenu/firmware_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/firmware_menu.cpp
@@ -91,7 +91,6 @@ void FirmwareMenu::render_item(const Item &item, int y, int index) const {
   const auto screen_width = screen.bounds.w;
 
   const int bar_margin = 2;
-  const int bar_height = item_h - bar_margin * 2;
   const int bar_width = 75;
   int bar_x = screen_width - bar_width - item_padding_x;
 

--- a/32blit-stm32/Src/SystemMenu/firmware_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/firmware_menu.cpp
@@ -23,7 +23,6 @@ using namespace blit;
 // Some declarations from 32blit.cpp that we need to do system things
 //
 extern bool take_screenshot;
-void blit_update_volume();
 
 //
 // To use the Item class without specifier

--- a/32blit-stm32/Src/SystemMenu/system_menu_controller.cpp
+++ b/32blit-stm32/Src/SystemMenu/system_menu_controller.cpp
@@ -90,7 +90,6 @@ void SystemMenuController::render(uint32_t time) {
 //
 void SystemMenuController::render_header_battery_status(uint32_t time) {
   const int screen_width = blit::screen.bounds.w;
-  const int screen_height = blit::screen.bounds.h;
 
   const Pen foreground_colour = get_menu_colour(10);
   const Pen bar_background_color = get_menu_colour(3);

--- a/32blit-stm32/Src/adc.c
+++ b/32blit-stm32/Src/adc.c
@@ -37,7 +37,7 @@ void MX_ADC1_Init(void)
   ADC_MultiModeTypeDef multimode = {0};
   ADC_ChannelConfTypeDef sConfig = {0};
 
-  /** Common config 
+  /** Common config
   */
   hadc1.Instance = ADC1;
   hadc1.Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV4;
@@ -62,14 +62,14 @@ void MX_ADC1_Init(void)
   {
     Error_Handler();
   }
-  /** Configure the ADC multi-mode 
+  /** Configure the ADC multi-mode
   */
   multimode.Mode = ADC_MODE_INDEPENDENT;
   if (HAL_ADCEx_MultiModeConfigChannel(&hadc1, &multimode) != HAL_OK)
   {
     Error_Handler();
   }
-  /** Configure Regular Channel 
+  /** Configure Regular Channel
   */
   sConfig.Channel = ADC_CHANNEL_4;
   sConfig.Rank = ADC_REGULAR_RANK_1;
@@ -81,7 +81,7 @@ void MX_ADC1_Init(void)
   {
     Error_Handler();
   }
-  /** Configure Regular Channel 
+  /** Configure Regular Channel
   */
   sConfig.Channel = ADC_CHANNEL_10;
   sConfig.Rank = ADC_REGULAR_RANK_2;
@@ -96,7 +96,7 @@ void MX_ADC3_Init(void)
 {
   ADC_ChannelConfTypeDef sConfig = {0};
 
-  /** Common config 
+  /** Common config
   */
   hadc3.Instance = ADC3;
   hadc3.Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV4;
@@ -121,7 +121,7 @@ void MX_ADC3_Init(void)
   {
     Error_Handler();
   }
-  /** Configure Regular Channel 
+  /** Configure Regular Channel
   */
   sConfig.Channel = ADC_CHANNEL_11;
   sConfig.Rank = ADC_REGULAR_RANK_1;
@@ -133,7 +133,7 @@ void MX_ADC3_Init(void)
   {
     Error_Handler();
   }
-  /** Configure Regular Channel 
+  /** Configure Regular Channel
   */
   sConfig.Channel = ADC_CHANNEL_0;
   sConfig.Rank = ADC_REGULAR_RANK_2;
@@ -141,7 +141,7 @@ void MX_ADC3_Init(void)
   {
     Error_Handler();
   }
-  /** Configure Regular Channel 
+  /** Configure Regular Channel
   */
   sConfig.Channel = ADC_CHANNEL_1;
   sConfig.Rank = ADC_REGULAR_RANK_3;
@@ -149,7 +149,7 @@ void MX_ADC3_Init(void)
   {
     Error_Handler();
   }
-  /** Configure Regular Channel 
+  /** Configure Regular Channel
    * Reading ADC channel twice, just to make sure
    * I kid. This is actually here because the DMA transfer is circular,
    * and 3 readings into a 32-sample buffer means we have a phase problem.
@@ -166,8 +166,6 @@ void MX_ADC3_Init(void)
 
 void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
 {
-
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(adcHandle->Instance==ADC1)
   {
   /* USER CODE BEGIN ADC1_MspInit 0 */
@@ -175,9 +173,9 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
   /* USER CODE END ADC1_MspInit 0 */
     /* ADC1 clock enable */
     __HAL_RCC_ADC12_CLK_ENABLE();
-  
+
     __HAL_RCC_GPIOC_CLK_ENABLE();
- 
+
 
     /* ADC1 DMA Init */
     /* ADC1 Init */
@@ -212,14 +210,14 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* adcHandle)
   /* USER CODE END ADC3_MspInit 0 */
     /* ADC3 clock enable */
     __HAL_RCC_ADC3_CLK_ENABLE();
-  
+
     __HAL_RCC_GPIOC_CLK_ENABLE();
-    /**ADC3 GPIO Configuration    
+    /**ADC3 GPIO Configuration
     PC1     ------> ADC3_INP11
     PC2_C     ------> ADC3_INP0
-    PC3_C     ------> ADC3_INP1 
+    PC3_C     ------> ADC3_INP1
     */
- 
+
     HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC2, SYSCFG_SWITCH_PC2_OPEN);
 
     HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC3, SYSCFG_SWITCH_PC3_OPEN);
@@ -262,10 +260,10 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* adcHandle)
   /* USER CODE END ADC1_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_ADC12_CLK_DISABLE();
-  
-    /**ADC1 GPIO Configuration    
+
+    /**ADC1 GPIO Configuration
     PC0     ------> ADC1_INP10
-    PC4     ------> ADC1_INP4 
+    PC4     ------> ADC1_INP4
     */
     HAL_GPIO_DeInit(GPIOC, JOYSTICK_Y_Pin|JOYSTICK_X_Pin);
 
@@ -285,11 +283,11 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* adcHandle)
   /* USER CODE END ADC3_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_ADC3_CLK_DISABLE();
-  
-    /**ADC3 GPIO Configuration    
+
+    /**ADC3 GPIO Configuration
     PC1     ------> ADC3_INP11
     PC2_C     ------> ADC3_INP0
-    PC3_C     ------> ADC3_INP1 
+    PC3_C     ------> ADC3_INP1
     */
     HAL_GPIO_DeInit(USER_LEFT1_GPIO_Port, USER_LEFT1_Pin);
 
@@ -302,7 +300,7 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* adcHandle)
 
   /* USER CODE END ADC3_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -284,8 +284,6 @@ namespace display {
 	}
 
   void flip(const Surface &source) {
-    static uint32_t flip_time = 0;
-
     // switch colour mode if needed
     if(need_ltdc_mode_update) {
       update_ltdc_for_mode();

--- a/32blit-stm32/Src/fatfs_sd.c
+++ b/32blit-stm32/Src/fatfs_sd.c
@@ -120,7 +120,6 @@ static uint8_t SD_ReadyWait(void)
 /* power on */
 static void SD_PowerOn(void)
 {
-	uint8_t args[6];
 	uint32_t cnt = 0x1FFF;
 
 	/* transmit bytes to wake up */

--- a/32blit-stm32/Src/i2c.c
+++ b/32blit-stm32/Src/i2c.c
@@ -43,13 +43,13 @@ void MX_I2C4_Init(void)
   {
     Error_Handler();
   }
-  /** Configure Analogue filter 
+  /** Configure Analogue filter
   */
   if (HAL_I2CEx_ConfigAnalogFilter(&hi2c4, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
   {
     Error_Handler();
   }
-  /** Configure Digital filter 
+  /** Configure Digital filter
   */
   if (HAL_I2CEx_ConfigDigitalFilter(&hi2c4, 0) != HAL_OK)
   {
@@ -60,14 +60,12 @@ void MX_I2C4_Init(void)
 
 void HAL_I2C_MspInit(I2C_HandleTypeDef* i2cHandle)
 {
-
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(i2cHandle->Instance==I2C4)
   {
   /* USER CODE BEGIN I2C4_MspInit 0 */
 
   /* USER CODE END I2C4_MspInit 0 */
- 
+
     /* I2C4 clock enable */
     __HAL_RCC_I2C4_CLK_ENABLE();
 
@@ -100,7 +98,7 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef* i2cHandle)
 
   /* USER CODE END I2C4_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/32blit-stm32/Src/jpeg.cpp
+++ b/32blit-stm32/Src/jpeg.cpp
@@ -63,13 +63,16 @@ blit::JPEGImage blit_decode_jpeg_buffer(const uint8_t *ptr, uint32_t len, blit::
   jpeg_in_len = len;
   jpeg_in_off = 0;
   jpeg_in_file = nullptr;
-  
+
   jpeg_out_block = 0;
 
   jpeg_handle.Instance = JPEG;
   HAL_JPEG_Init(&jpeg_handle);
 
   auto status = HAL_JPEG_Decode(&jpeg_handle, (uint8_t *)ptr, len, jpeg_dec_block, jpeg_max_block_len, 0xFFFFFFFF);
+
+  if(status != HAL_OK)
+    return {blit::Size(0, 0), nullptr};
 
   JPEG_ConfTypeDef conf;
   HAL_JPEG_GetInfo(&jpeg_handle, &conf);
@@ -96,13 +99,16 @@ blit::JPEGImage blit_decode_jpeg_file(const std::string &filename, blit::Allocat
   jpeg_in_buf = new uint8_t[1024];
   jpeg_in_len = read_file(file, 0, 1024, (char *)jpeg_in_buf);
   jpeg_in_off = 0;
-  
+
   jpeg_out_block = 0;
 
   jpeg_handle.Instance = JPEG;
   HAL_JPEG_Init(&jpeg_handle);
 
   auto status = HAL_JPEG_Decode(&jpeg_handle, (uint8_t *)jpeg_in_buf, jpeg_in_len, jpeg_dec_block, jpeg_max_block_len, 0xFFFFFFFF);
+
+  if(status != HAL_OK)
+    return {blit::Size(0, 0), nullptr};
 
   JPEG_ConfTypeDef conf;
   HAL_JPEG_GetInfo(&jpeg_handle, &conf);

--- a/32blit-stm32/Src/main.c
+++ b/32blit-stm32/Src/main.c
@@ -173,13 +173,6 @@ int main(void)
   /* USER CODE BEGIN WHILE */
   while (1)
   {
-    uint32_t t_start = blit::now();
-
-//    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-//    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-//    uint32_t uTicksPerUs = SystemCoreClock / 1000000;
-//    uint32_t uTimeStart = DWT->CYCCNT;
-
     blit_tick();
     //HAL_Delay(1000);
 
@@ -192,9 +185,6 @@ int main(void)
     // handle CDC input
     g_commandStream.Stream();
 
-    uint32_t t_elapsed = blit::now() - t_start;
-//    uint32_t uTimeElapsed = (DWT->CYCCNT - uTimeStart)/uTicksPerUs;
-//    printf("%lu, %lu\n\r", t_elapsed, uTimeElapsed);
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */

--- a/32blit-stm32/Src/multiplayer.cpp
+++ b/32blit-stm32/Src/multiplayer.cpp
@@ -173,8 +173,10 @@ namespace multiplayer {
       return;
 
     // header
-    cdc_send((uint8_t *)"32BLUSER", 8);
-    cdc_send((uint8_t *)&length, 2);
+    uint8_t buf[]{'3', '2', 'B', 'L', 'U', 'S', 'E','R',
+      uint8_t(length & 0xFF), uint8_t(length >> 8)
+    };
+    cdc_send(buf, 10);
 
     cdc_send((uint8_t *)data, length);
   }

--- a/32blit-stm32/Src/quadspi.c
+++ b/32blit-stm32/Src/quadspi.c
@@ -47,8 +47,6 @@ void MX_QUADSPI_Init(void)
 
 void HAL_QSPI_MspInit(QSPI_HandleTypeDef* qspiHandle)
 {
-
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(qspiHandle->Instance==QUADSPI)
   {
   /* USER CODE BEGIN QUADSPI_MspInit 0 */
@@ -59,7 +57,7 @@ void HAL_QSPI_MspInit(QSPI_HandleTypeDef* qspiHandle)
 
     __HAL_RCC_QSPI_FORCE_RESET();
     __HAL_RCC_QSPI_RELEASE_RESET();
-  
+
 
   /* USER CODE BEGIN QUADSPI_MspInit 1 */
 
@@ -77,14 +75,14 @@ void HAL_QSPI_MspDeInit(QSPI_HandleTypeDef* qspiHandle)
   /* USER CODE END QUADSPI_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_QSPI_CLK_DISABLE();
-  
-    /**QUADSPI GPIO Configuration    
+
+    /**QUADSPI GPIO Configuration
     PB2     ------> QUADSPI_CLK
     PE7     ------> QUADSPI_BK2_IO0
     PE8     ------> QUADSPI_BK2_IO1
     PE9     ------> QUADSPI_BK2_IO2
     PE10     ------> QUADSPI_BK2_IO3
-    PC11     ------> QUADSPI_BK2_NCS 
+    PC11     ------> QUADSPI_BK2_NCS
     */
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_2);
 
@@ -96,7 +94,7 @@ void HAL_QSPI_MspDeInit(QSPI_HandleTypeDef* qspiHandle)
 
   /* USER CODE END QUADSPI_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 /**

--- a/32blit-stm32/Src/sound.cpp
+++ b/32blit-stm32/Src/sound.cpp
@@ -42,8 +42,6 @@ namespace sound {
     HAL_NVIC_EnableIRQ(TIM6_DAC_IRQn);
     __TIM6_CLK_ENABLE();
 
-    TIM_MasterConfigTypeDef sMasterConfig = {0};
-
     htim6.Instance = TIM6;
     htim6.Init.Prescaler = 310;
     htim6.Init.CounterMode = TIM_COUNTERMODE_UP;

--- a/32blit-stm32/Src/spi.c
+++ b/32blit-stm32/Src/spi.c
@@ -96,8 +96,6 @@ void MX_SPI4_Init(void)
 
 void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
 {
-
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(spiHandle->Instance==SPI1)
   {
   /* USER CODE BEGIN SPI1_MspInit 0 */
@@ -105,7 +103,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
   /* USER CODE END SPI1_MspInit 0 */
     /* SPI1 clock enable */
     __HAL_RCC_SPI1_CLK_ENABLE();
-  
+
 
 
   /* USER CODE BEGIN SPI1_MspInit 1 */
@@ -119,7 +117,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
   /* USER CODE END SPI4_MspInit 0 */
     /* SPI4 clock enable */
     __HAL_RCC_SPI4_CLK_ENABLE();
-  
+
 
   /* USER CODE BEGIN SPI4_MspInit 1 */
 
@@ -137,11 +135,11 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* spiHandle)
   /* USER CODE END SPI1_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_SPI1_CLK_DISABLE();
-  
-    /**SPI1 GPIO Configuration    
+
+    /**SPI1 GPIO Configuration
     PA7     ------> SPI1_MOSI
     PB3 (JTDO/TRACESWO)     ------> SPI1_SCK
-    PB4 (NJTRST)     ------> SPI1_MISO 
+    PB4 (NJTRST)     ------> SPI1_MISO
     */
     HAL_GPIO_DeInit(SD_SPI1_MOSI_GPIO_Port, SD_SPI1_MOSI_Pin);
 
@@ -158,10 +156,10 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* spiHandle)
   /* USER CODE END SPI4_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_SPI4_CLK_DISABLE();
-  
-    /**SPI4 GPIO Configuration    
+
+    /**SPI4 GPIO Configuration
     PE2     ------> SPI4_SCK
-    PE6     ------> SPI4_MOSI 
+    PE6     ------> SPI4_MOSI
     */
     HAL_GPIO_DeInit(GPIOE, LCD_SPI4_SCK_Pin|LCD_SPI4_MOSI_Pin);
 
@@ -169,7 +167,7 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* spiHandle)
 
   /* USER CODE END SPI4_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/32blit-stm32/Src/tim.c
+++ b/32blit-stm32/Src/tim.c
@@ -271,7 +271,7 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* tim_baseHandle)
 
   /* USER CODE END TIM16_MspInit 1 */
   }
-  
+
 }
 
 void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef* tim_pwmHandle)
@@ -292,10 +292,6 @@ void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef* tim_pwmHandle)
 
 void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
 {
-
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-
-
   if(timHandle->Instance==TIM3)
   {
   /* USER CODE BEGIN TIM3_MspPostInit 0 */
@@ -305,7 +301,7 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
 
   /* USER CODE BEGIN TIM3_MspPostInit 1 */
     __HAL_RCC_GPIOB_CLK_ENABLE();
-  
+
     HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_2); // Blue LED
     HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_3); // Red LED
     HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_4); // Green LED
@@ -317,7 +313,7 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM4_MspPostInit 0 */
 
   /* USER CODE END TIM4_MspPostInit 0 */
-  
+
     __HAL_RCC_GPIOB_CLK_ENABLE();
 
   /* USER CODE BEGIN TIM4_MspPostInit 1 */
@@ -329,9 +325,9 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef* timHandle)
   /* USER CODE BEGIN TIM15_MspPostInit 0 */
 
   /* USER CODE END TIM15_MspPostInit 0 */
-  
+
     __HAL_RCC_GPIOE_CLK_ENABLE();
- 
+
 
   /* USER CODE BEGIN TIM15_MspPostInit 1 */
     HAL_TIM_PWM_Start(&htim15, TIM_CHANNEL_1);
@@ -423,7 +419,7 @@ void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef* tim_pwmHandle)
 
   /* USER CODE END TIM15_MspDeInit 1 */
   }
-} 
+}
 
 /* USER CODE BEGIN 1 */
 

--- a/32blit-stm32/Src/tim.c
+++ b/32blit-stm32/Src/tim.c
@@ -164,7 +164,6 @@ void MX_TIM4_Init(void)
 /* TIM15 init function */
 void MX_TIM15_Init(void)
 {
-  TIM_ClockConfigTypeDef sClockSourceConfig = {0};
   TIM_MasterConfigTypeDef sMasterConfig = {0};
   TIM_OC_InitTypeDef sConfigOC = {0};
   TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};

--- a/32blit-stm32/Src/usbd_conf.c
+++ b/32blit-stm32/Src/usbd_conf.c
@@ -65,13 +65,12 @@ USBD_StatusTypeDef USBD_Get_USB_Status(HAL_StatusTypeDef hal_status);
 
 void HAL_PCD_MspInit(PCD_HandleTypeDef* pcdHandle)
 {
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(pcdHandle->Instance==USB_OTG_HS)
   {
   /* USER CODE BEGIN USB_OTG_HS_MspInit 0 */
 
   /* USER CODE END USB_OTG_HS_MspInit 0 */
-  
+
     /* Peripheral clock enable */
     __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
 
@@ -171,7 +170,7 @@ static void PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 #else
 void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
-{ 
+{
   USBD_SpeedTypeDef speed = USBD_SPEED_FULL;
 
   if ( hpcd->Init.speed == PCD_SPEED_HIGH)
@@ -363,8 +362,8 @@ USBD_StatusTypeDef USBD_LL_DeInit(USBD_HandleTypeDef *pdev)
   hal_status = HAL_PCD_DeInit(pdev->pData);
 
   usb_status =  USBD_Get_USB_Status(hal_status);
-  
-  return usb_status; 
+
+  return usb_status;
 }
 
 /**
@@ -376,11 +375,11 @@ USBD_StatusTypeDef USBD_LL_Start(USBD_HandleTypeDef *pdev)
 {
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
- 
+
   hal_status = HAL_PCD_Start(pdev->pData);
-  
-  usb_status =  USBD_Get_USB_Status(hal_status);     
-  
+
+  usb_status =  USBD_Get_USB_Status(hal_status);
+
   return usb_status;
 }
 
@@ -395,9 +394,9 @@ USBD_StatusTypeDef USBD_LL_Stop(USBD_HandleTypeDef *pdev)
   USBD_StatusTypeDef usb_status = USBD_OK;
 
   hal_status = HAL_PCD_Stop(pdev->pData);
-  
+
   usb_status =  USBD_Get_USB_Status(hal_status);
- 
+
   return usb_status;
 }
 
@@ -417,7 +416,7 @@ USBD_StatusTypeDef USBD_LL_OpenEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr, uin
   hal_status = HAL_PCD_EP_Open(pdev->pData, ep_addr, ep_mps, ep_type);
 
   usb_status =  USBD_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 
@@ -431,12 +430,12 @@ USBD_StatusTypeDef USBD_LL_CloseEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
 {
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
-  
+
   hal_status = HAL_PCD_EP_Close(pdev->pData, ep_addr);
-  
-  usb_status =  USBD_Get_USB_Status(hal_status);    
- 
-  return usb_status;  
+
+  usb_status =  USBD_Get_USB_Status(hal_status);
+
+  return usb_status;
 }
 
 /**
@@ -449,12 +448,12 @@ USBD_StatusTypeDef USBD_LL_FlushEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
 {
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
-  
+
   hal_status = HAL_PCD_EP_Flush(pdev->pData, ep_addr);
-  
-  usb_status =  USBD_Get_USB_Status(hal_status);   
-  
-  return usb_status;  
+
+  usb_status =  USBD_Get_USB_Status(hal_status);
+
+  return usb_status;
 }
 
 /**
@@ -467,12 +466,12 @@ USBD_StatusTypeDef USBD_LL_StallEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
 {
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
-  
+
   hal_status = HAL_PCD_EP_SetStall(pdev->pData, ep_addr);
 
   usb_status =  USBD_Get_USB_Status(hal_status);
-  
-  return usb_status;  
+
+  return usb_status;
 }
 
 /**
@@ -485,12 +484,12 @@ USBD_StatusTypeDef USBD_LL_ClearStallEP(USBD_HandleTypeDef *pdev, uint8_t ep_add
 {
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
-  
+
   hal_status = HAL_PCD_EP_ClrStall(pdev->pData, ep_addr);
-    
-  usb_status =  USBD_Get_USB_Status(hal_status);  
-  
-  return usb_status; 
+
+  usb_status =  USBD_Get_USB_Status(hal_status);
+
+  return usb_status;
 }
 
 /**
@@ -502,14 +501,14 @@ USBD_StatusTypeDef USBD_LL_ClearStallEP(USBD_HandleTypeDef *pdev, uint8_t ep_add
 uint8_t USBD_LL_IsStallEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
 {
   PCD_HandleTypeDef *hpcd = (PCD_HandleTypeDef*) pdev->pData;
-  
+
   if((ep_addr & 0x80) == 0x80)
   {
-    return hpcd->IN_ep[ep_addr & 0x7F].is_stall; 
+    return hpcd->IN_ep[ep_addr & 0x7F].is_stall;
   }
   else
   {
-    return hpcd->OUT_ep[ep_addr & 0x7F].is_stall; 
+    return hpcd->OUT_ep[ep_addr & 0x7F].is_stall;
   }
 }
 
@@ -523,12 +522,12 @@ USBD_StatusTypeDef USBD_LL_SetUSBAddress(USBD_HandleTypeDef *pdev, uint8_t dev_a
 {
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
-  
+
   hal_status = HAL_PCD_SetAddress(pdev->pData, dev_addr);
-  
+
   usb_status =  USBD_Get_USB_Status(hal_status);
-  
-  return usb_status;  
+
+  return usb_status;
 }
 
 /**
@@ -536,7 +535,7 @@ USBD_StatusTypeDef USBD_LL_SetUSBAddress(USBD_HandleTypeDef *pdev, uint8_t dev_a
   * @param  pdev: Device handle
   * @param  ep_addr: Endpoint number
   * @param  pbuf: Pointer to data to be sent
-  * @param  size: Data size    
+  * @param  size: Data size
   * @retval USBD status
   */
 USBD_StatusTypeDef USBD_LL_Transmit(USBD_HandleTypeDef *pdev, uint8_t ep_addr, uint8_t *pbuf, uint16_t size)
@@ -545,10 +544,10 @@ USBD_StatusTypeDef USBD_LL_Transmit(USBD_HandleTypeDef *pdev, uint8_t ep_addr, u
   USBD_StatusTypeDef usb_status = USBD_OK;
 
   hal_status = HAL_PCD_EP_Transmit(pdev->pData, ep_addr, pbuf, size);
-  
-  usb_status =  USBD_Get_USB_Status(hal_status); 
-  
-  return usb_status;    
+
+  usb_status =  USBD_Get_USB_Status(hal_status);
+
+  return usb_status;
 }
 
 /**
@@ -565,10 +564,10 @@ USBD_StatusTypeDef USBD_LL_PrepareReceive(USBD_HandleTypeDef *pdev, uint8_t ep_a
   USBD_StatusTypeDef usb_status = USBD_OK;
 
   hal_status = HAL_PCD_EP_Receive(pdev->pData, ep_addr, pbuf, size);
-  
-  usb_status =  USBD_Get_USB_Status(hal_status);   
-  
-  return usb_status; 
+
+  usb_status =  USBD_Get_USB_Status(hal_status);
+
+  return usb_status;
 }
 
 /**

--- a/32blit-stm32/Src/usbh_conf.c
+++ b/32blit-stm32/Src/usbh_conf.c
@@ -61,13 +61,12 @@ USBH_StatusTypeDef USBH_Get_USB_Status(HAL_StatusTypeDef hal_status);
 
 void HAL_HCD_MspInit(HCD_HandleTypeDef* hcdHandle)
 {
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if(hcdHandle->Instance==USB_OTG_HS)
   {
   /* USER CODE BEGIN USB_OTG_HS_MspInit 0 */
 
   /* USER CODE END USB_OTG_HS_MspInit 0 */
-  
+
     /* Peripheral clock enable */
     __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
 
@@ -150,7 +149,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
 void HAL_HCD_PortEnabled_Callback(HCD_HandleTypeDef *hhcd)
 {
   USBH_LL_PortEnabled(hhcd->pData);
-} 
+}
 
 /**
   * @brief  Port Port Disabled callback.
@@ -160,7 +159,7 @@ void HAL_HCD_PortEnabled_Callback(HCD_HandleTypeDef *hhcd)
 void HAL_HCD_PortDisabled_Callback(HCD_HandleTypeDef *hhcd)
 {
   USBH_LL_PortDisabled(hhcd->pData);
-} 
+}
 
 /*******************************************************************************
                        LL Driver Interface (USB Host Library --> HCD)
@@ -210,9 +209,9 @@ USBH_StatusTypeDef USBH_LL_DeInit(USBH_HandleTypeDef *phost)
   USBH_StatusTypeDef usb_status = USBH_OK;
 
   hal_status = HAL_HCD_DeInit(phost->pData);
-  
+
   usb_status = USBH_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 
@@ -229,7 +228,7 @@ USBH_StatusTypeDef USBH_LL_Start(USBH_HandleTypeDef *phost)
   hal_status = HAL_HCD_Start(phost->pData);
 
   usb_status = USBH_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 
@@ -246,7 +245,7 @@ USBH_StatusTypeDef USBH_LL_Stop(USBH_HandleTypeDef *phost)
   hal_status = HAL_HCD_Stop(phost->pData);
 
   usb_status = USBH_Get_USB_Status(hal_status);
- 
+
   return usb_status;
 }
 
@@ -291,9 +290,9 @@ USBH_StatusTypeDef USBH_LL_ResetPort(USBH_HandleTypeDef *phost)
   USBH_StatusTypeDef usb_status = USBH_OK;
 
   hal_status = HAL_HCD_ResetPort(phost->pData);
-  
+
   usb_status = USBH_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 
@@ -329,7 +328,7 @@ USBH_StatusTypeDef USBH_LL_OpenPipe(USBH_HandleTypeDef *phost, uint8_t pipe_num,
                                dev_address, speed, ep_type, mps);
 
   usb_status = USBH_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 
@@ -347,7 +346,7 @@ USBH_StatusTypeDef USBH_LL_ClosePipe(USBH_HandleTypeDef *phost, uint8_t pipe)
   hal_status = HAL_HCD_HC_Halt(phost->pData, pipe);
 
   usb_status = USBH_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 
@@ -401,7 +400,7 @@ USBH_StatusTypeDef USBH_LL_SubmitURB(USBH_HandleTypeDef *phost, uint8_t pipe, ui
                                         ep_type, token, pbuff, length,
                                         do_ping);
   usb_status =  USBH_Get_USB_Status(hal_status);
-  
+
   return usb_status;
 }
 

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -33,7 +33,7 @@ set(EXTERNAL_LOAD_ADDRESS_EXT 0x08000000)
 set(INITIALISE_QSPI_EXT 0)
 set(CDC_FIFO_BUFFERS_EXT 4)
 
-set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -Wno-unused-variable -Wno-write-strings -mno-pic-data-is-text-relative -mno-single-pic-base")
+set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -mno-pic-data-is-text-relative -mno-single-pic-base")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS} -fno-exceptions")

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -68,14 +68,11 @@ namespace blit {
   Surface null_surface(nullptr, PixelFormat::M, Size(0, 0));
   Surface &screen = null_surface;
 
-  uint32_t update_rate_ms = 10;
-  uint32_t pending_update_time = 0;
+  static const uint32_t update_rate_ms = 10;
+  static uint32_t pending_update_time = 0;
 
-  uint32_t render_rate_ms = 20;
-  uint32_t pending_render_time = 0;
-
-  uint32_t last_tick_time = 0;
-  uint32_t last_state = 0;
+  static uint32_t last_tick_time = 0;
+  static uint32_t last_state = 0;
 
   bool tick(uint32_t time) {
     if (last_tick_time == 0) {

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -28,7 +28,6 @@ namespace blit {
   int debugf(const char * psFormatString, ...);
 
   bool tick(uint32_t time);
-  void fast_tick(uint32_t time);
 
   const char *get_launch_path();
 }

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -132,12 +132,10 @@ static bool parse_file_metadata(FIL &fh, GameInfo &info) {
   if(header.magic == blit_game_magic) {
     uint8_t buf[10];
     f_lseek(&fh, (header.end - qspi_flash_address) + off);
-    auto res = f_read(&fh, buf, 10, &bytes_read);
+    f_read(&fh, buf, 10, &bytes_read);
 
     if(bytes_read == 10 && memcmp(buf, "BLITMETA", 8) == 0) {
       // don't bother reading the whole thing since we don't want the images
-      const auto metadata_len = sizeof(RawMetadata);
-
       RawMetadata raw_meta;
       f_read(&fh, &raw_meta, sizeof(RawMetadata), &bytes_read);
 
@@ -150,7 +148,7 @@ static bool parse_file_metadata(FIL &fh, GameInfo &info) {
     }
 
     // read category
-    res = f_read(&fh, buf, 8, &bytes_read);
+    f_read(&fh, buf, 8, &bytes_read);
     if(bytes_read == 8 && memcmp(buf, "BLITTYPE", 8) == 0) {
       RawTypeMetadata type_meta;
       f_read(&fh, &type_meta, sizeof(RawTypeMetadata), &bytes_read);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -128,10 +128,10 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
 
     offset = num_relocs * 4 + 8;
     // re-read header
-    f.read(offset, sizeof(header), (char *)&header);
+    read = f.read(offset, sizeof(header), (char *)&header);
   }
 
-  if(header.magic == blit_game_magic) {
+  if(read == sizeof(header) && header.magic == blit_game_magic) {
     uint8_t buf[10];
 
     offset += (header.end & 0x1FFFFFF);


### PR DESCRIPTION
Noticed some of these while doing other stuff and a lot more after finding that the toolchain had `-Wno-unused-variable` set.

Last commit fixes the initial flash of uninitialised data after being powered off (by clearing LTDC ram when `persist` needs reset). It does add a warning about writing out of bounds that I can't seem to avoid.