### PR TITLE
More docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,9 @@ Finished 32blit games can be released simultaneously for Linux, Windows, macOS a
 
 # You Will Need
 
-1. Some experience writing/compiling C/C++ software
-2. `gcc` or Visual Studio for compiling test builds
-3. `gcc-arm-none-eabi` for compiling STM32 builds
-4. `cmake` and `make` for building 32blit libraries and examples
-5. _Python3_ installed, along with _pip3_ (`sudo apt install python3 python3-pip` on Ubuntu/WSL) and the [32blit tools](https://github.com/32blit/32blit-tools) `pip3 install 32blit`
-6. Ubuntu on Windows 10 WSL (_Windows Subsystem for Linux_), or a Linux VM if you prefer.
+Some experience writing/compiling C/C++ software is required.
 
-For more information about how to build on the various systems, refer to the platform specific docs in the `docs` folder!
-
-# More docs!
-
-Refer to the OS specific docs:
+OS specific docs, these cover setup and command-line builds:
 
 * [Linux](docs/Linux.md)
 * [Linux - ChromeOS](docs/ChromeOS.md)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Refer to the OS specific docs:
 
 * [Linux](docs/Linux.md)
 * [Linux - ChromeOS](docs/ChromeOS.md)
-* [Windows - Visual Studio](docs/Windows-VisualStudio.md)
-* [Windows - Command Line / other editor](docs/Windows.md)
+* [Windows](docs/Windows.md)
 * [Windows - WSL (Advanced)](docs/Windows-WSL.md)
 * [macOS](docs/macOS.md)
 

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -9,7 +9,21 @@ These instructions cover building 32blit on Linux.
 
 ## Prerequisites
 
-First install the required tools:
+You'll need to install:
+ - Git
+ - CMake (at least 3.9)
+ - Make (or another build tool like Ninja)
+ - Python (at least 3.6) + pip
+ - [The 32blit tools](https://github.com/32blit/32blit-tools)
+
+For local builds:
+ - GCC
+ - SDL2 + SDL2_image + SDL2_net
+
+For 32Blit device builds:
+ - Arm Embedded GCC (`gcc-arm-none-eabi`, versions 7.x-9.x should work)
+
+New enough versions of these exist in at least Debian "buster" and Ubuntu 20.04.
 
 ```
 sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev libsdl2-net-dev unzip

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -3,11 +3,11 @@
 These instructions cover building 32blit on Linux.
 
 - [Prerequisites](#prerequisites)
-  - [Building & Running on 32Blit](#building--running-on-32blit)
-  - [Building & Running Locally](#building--running-locally)
-    - [Build Everything](#build-everything)
+- [Building & Running on 32Blit](#building--running-on-32blit)
+- [Building & Running Locally](#building--running-locally)
+  - [Build Everything](#build-everything)
 
-# Prerequisites
+## Prerequisites
 
 First install the required tools:
 

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -55,7 +55,7 @@ You can use WSL on Windows to cross-compile your project (or any 32Blit example)
 
 If you're more familiar with Visual Studio then you should [follow the instructions in Windows-VisualStudio.md](Windows-VisualStudio.md)
 
-You will need to cross-compile SDL2 for MinGW and install both it, and SDL2-image.
+You will need to install SDL2 and SDL2_image/_net for MinGW.
 
 ### Installing the MinGW compiler/tools
 

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -10,7 +10,7 @@ A basic knowledge of the Linux command-line, installing tools and compiling code
   - [Installing requirements inside WSL](#installing-requirements-inside-wsl)
 - [Building & Running on 32Blit](#building--running-on-32blit)
 - [Building & Running Locally](#building--running-locally)
-  - [Installing the MinGW compiler/tools](#installing-the-mingw-compiler-tools)
+  - [Installing the MinGW compiler/tools](#installing-the-mingw-compilertools)
   - [Installing SDL2, SDL2_image and SDL2_net](#installing-sdl2-sdl2_image-and-sdl2_net)
     - [SDL2](#sdl2)
     - [SDL2_image](#sdl2_image)
@@ -31,6 +31,7 @@ After that, proceed to the Microsoft Store to download Ubuntu for WSL.
 ### Installing requirements inside WSL
 
 The following requirements enable cross-compile to 32Blit via ARM GCC:
+(These are similar to the [Linux requirements](Linux.md#prerequisites), see those for more details)
 
 ```
 sudo apt install gcc gcc-arm-none-eabi unzip cmake make python3 python3-pip

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -1,8 +1,9 @@
 # Building & Running on Windows <!-- omit in toc -->
 
-These instructions cover building 32blit on Windows (without WSL or a full Visual Studio install).
+These instructions cover building 32blit on Windows (without WSL).
 
 - [Prerequisites](#prerequisites)
+- [Using Visual Studio](#using-visual-studio)
 - [Building & Running on 32Blit](#building--running-on-32blit)
 - [Building & Running Locally](#building--running-locally)
   - [Build Everything](#build-everything)
@@ -13,7 +14,7 @@ You'll need to install:
 
  - [Git for Windows](https://git-scm.com/download/win)
  - [Python](https://www.python.org/downloads/)
- - The [Visual Studio build tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) (For local builds, select "C++ build tools"). This includes a copy of CMake.
+ - At least the [Visual Studio build tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) (For local builds, select "C++ build tools"). This includes a copy of CMake. A full Visual Studio install can also be used.
  - The [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) (For 32blit device builds, use the 9-2020-q2-update version). Make sure to select the "Add path to environment variable" at the end of the setup.
 
 Now open "Developer Command Prompt for VS 2019" and install the 32blit tools:
@@ -29,6 +30,9 @@ WARNING: The script 32blit.exe is installed in 'C:\Users\[Name]\AppData\Local\Pr
 ```
 
 You will either need to add that to your PATH, or run the tools as `py -m ttblit ...` instead of `32blit ...`.
+
+## Using Visual Studio
+To build using Visual Studio [see here](Windows-VisualStudio.md). The rest of these instructions cover command-line builds.
 
 ## Building & Running on 32Blit
 

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -3,11 +3,11 @@
 These instructions cover building 32blit on Windows (without WSL or a full Visual Studio install).
 
 - [Prerequisites](#prerequisites)
-  - [Building & Running on 32Blit](#building--running-on-32blit)
-  - [Building & Running Locally](#building--running-locally)
-    - [Build Everything](#build-everything)
+- [Building & Running on 32Blit](#building--running-on-32blit)
+- [Building & Running Locally](#building--running-locally)
+  - [Build Everything](#build-everything)
 
-# Prerequisites
+## Prerequisites
 
 You'll need to install:
 

--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -3,11 +3,10 @@
 These instructions cover building 32blit on macOS.
 
 - [Prerequisites](#prerequisites)
-- [Python3](#python3)
-  - [Installing python3](#installing-python3)
-  - [Installing pip3 dependecies](#installing-pip3-dependecies)
-  - [Verifying install](#verifying-install)
-- [Installing `gcc-arm-none-eabi`](#installing-gcc-arm-none-eabi)
+  - [Python3](#python3)
+    - [Installing python3](#installing-python3)
+    - [Installing pip3 dependecies](#installing-pip3-dependecies)
+  - [Installing `gcc-arm-none-eabi`](#installing-gcc-arm-none-eabi)
 - [Building & Running on 32Blit](#building--running-on-32blit)
 - [Building & Running Locally](#building--running-locally)
   - [Build Everything](#build-everything)
@@ -22,15 +21,15 @@ xcode-select --install
 brew install cmake
 ```
 
-## Python3
+### Python3
 
 Before trying to install python3, it's worth checking if you already have it installed (and if so, which version), by jumping to 'Verifying install', below. If you do already have it installed, skip this section.
 
-### Installing python3
+#### Installing python3
 
 Installing `python3` can be done with homebrew with a simple `brew install python` which installs both `python3` and `pip3`.
 
-###  Installing pip3 dependecies
+####  Installing pip3 dependecies
 
 before installing 32blit tools, some binary requirements are needed:
 
@@ -48,7 +47,7 @@ pip3 install 32blit
 TODO: Document install of `construct` and `bitstring` for Python 3 (probably need a requirements.txt for the tools directory)
 
 
-###  Verifying install
+####  Verifying install
 
 ``` shell
 python3 --version
@@ -62,7 +61,7 @@ pip3 --version
 (expected output `pip x.x.x from /usr/local/lib/python3.7/site-packages/pip (python 3.7)` or similar)
 
 <a name="gcc"/></a>
-## Installing `gcc-arm-none-eabi`
+### Installing `gcc-arm-none-eabi`
 
 Once this is done, you'll need to install `gcc-arm-none-eabi`. The easiest way to install this tool is via homebrew with the following source:
 


### PR DESCRIPTION
Main improvement is prioritising the "generic" Windows setup over the VS one, as it covers all the dependencies. This makes the OS setup docs all cover the same thing: installing dependencies and command-line builds.

Also more specific Linux requirements and not listing "building" under "prerequisites" in most of the docs.