### PR TITLE
Less resets for launcher/game switching

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -75,6 +75,8 @@ static bool (*user_tick)(uint32_t time) = nullptr;
 static void (*user_render)(uint32_t time) = nullptr;
 static bool user_code_disabled = false;
 
+static bool game_switch_requested = false;
+
 static void update_active();
 
 void DFUBoot(void)
@@ -231,6 +233,18 @@ void blit_tick() {
   }
 
   do_tick(blit::now());
+
+  // handle delayed switch
+  if(game_switch_requested) {
+    user_tick = nullptr;
+    if(!blit_switch_execution(persist.last_game_offset, true)) {
+      // new game failed and old game will now be broken
+      // reset and let the firmware show the error
+      SCB_CleanDCache();
+      NVIC_SystemReset();
+    }
+    game_switch_requested = false;
+  }
 }
 
 bool blit_sd_detected() {
@@ -685,21 +699,14 @@ bool blit_switch_execution(uint32_t address, bool force_game)
   init_api_shared();
 
   // returning from game running on top of the firmware
-  if(user_tick) {
-    // TODO? should be able to avoid the reset for `force_game` / game -> game by waiting for user code to return before switching
-    if(force_game)
-      persist.last_game_offset = address;
-
+  if(user_tick && !force_game) {
     user_tick = nullptr;
     user_render = nullptr;
     blit::render = ::render;
     blit::update = ::update;
     do_tick = blit::tick;
 
-    // TODO: may be possible to return to the menu without a hard reset but currently flashing doesn't work
-    SCB_CleanDCache();
-    NVIC_SystemReset();
-    return true; // can't get here
+    return true;
   }
 
 	// switch to user app in external flash
@@ -709,6 +716,15 @@ bool blit_switch_execution(uint32_t address, bool force_game)
     auto game_header = ((__IO BlitGameHeader *) (EXTERNAL_LOAD_ADDRESS + address));
 
     if(game_header->magic == blit_game_magic) {
+
+      persist.last_game_offset = address;
+
+      // game possibly running, wait until it isn't
+      if(user_tick) {
+        game_switch_requested = true;
+        return true;
+      }
+
       // load function pointers
       auto init = (BlitInitFunction)((uint8_t *)game_header->init + address);
 
@@ -716,13 +732,9 @@ bool blit_switch_execution(uint32_t address, bool force_game)
       user_render = (BlitRenderFunction) ((uint8_t *)game_header->render + address);
       user_tick = (BlitTickFunction) ((uint8_t *)game_header->tick + address);
 
-      persist.last_game_offset = address;
-
       if(!init(address)) {
         user_render = nullptr;
         user_tick = nullptr;
-        // don't try to auto-launch this game again
-        persist.reset_target = prtFirmware;
 
         qspi_disable_memorymapped_mode();
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -97,6 +97,9 @@ static void init_api_shared() {
   api.vibration = 0.0f;
   api.LED = Pen();
 
+  for(int i = 0; i < CHANNEL_COUNT; i++)
+    api.channels[i] = AudioChannel();
+
   api.message_received = nullptr;
 }
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -702,6 +702,11 @@ bool blit_switch_execution(uint32_t address, bool force_game)
   if(user_tick && !force_game) {
     user_tick = nullptr;
     user_render = nullptr;
+
+    // close the menu (otherwise we'll end up in an inconsistent state)
+    if(blit::update == blit_menu_update)
+      blit_menu();
+
     blit::render = ::render;
     blit::update = ::update;
     do_tick = blit::tick;

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -193,6 +193,7 @@ void blit_tick() {
       blit::LED.r = 0;
       blit_switch_execution(0, false);
     }
+    exit_game = false;
   }
 
   if(toggle_menu) {

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -46,6 +46,7 @@ std::list<HandlerInfo> handlers; // flashed games that can "launch" files
 std::list<std::tuple<uint16_t, uint16_t>> free_space; // block start, count
 
 uint32_t launcher_offset = ~0;
+bool flash_scanned = false;
 
 Dialog dialog;
 
@@ -641,6 +642,7 @@ void init() {
   screen.clear();
 
   scan_flash();
+  flash_scanned = true;
 
   // register PROG
   g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'P', 'R', 'O', 'G'>::value, &flashLoader);
@@ -693,7 +695,7 @@ void init() {
 
 void render(uint32_t time) {
 
-  if(launcher_offset == 0xFFFFFFFF) {
+  if(flash_scanned && launcher_offset == 0xFFFFFFFF) {
     screen.pen = Pen(0, 0, 0);
     screen.clear();
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -712,6 +712,10 @@ void render(uint32_t time) {
 void update(uint32_t time) {
   if(dialog.update())
     return;
+
+  // no game or launcher running, fix this
+  if(launcher_offset != 0xFFFFFFFF && !blit_user_code_running())
+    start_launcher();
 }
 
 // below here are the CDC handlers

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -638,11 +638,10 @@ void init() {
   api.flash_to_tmp = flash_to_tmp;
   api.tmp_file_closed = tmp_file_closed;
 
-  set_screen_mode(ScreenMode::hires);
-  screen.clear();
-
   scan_flash();
   flash_scanned = true;
+
+  set_screen_mode(ScreenMode::hires);
 
   // register PROG
   g_commandStream.AddCommandHandler(CDCCommandHandler::CDCFourCCMake<'P', 'R', 'O', 'G'>::value, &flashLoader);


### PR DESCRIPTION
First two commits improve firmware updates (would show the "no launcher" screen while cleaning up). The rest avoid resetting while launching a game (restoring the behaviour before the launcher split) and exiting a game (a TODO since the firmware split).

(Bug fixed by the last commit only exists with #652 + this)