### PR TITLE
Fix some paths

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -4,7 +4,9 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_C_COMPILER arm-none-eabi-gcc CACHE PATH "Path to C compiler")
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++ CACHE PATH "Path to C++ compiler")
 
-set(CMAKE_SIZE arm-none-eabi-size CACHE PATH "Path to size tool")
+find_program(CMAKE_SIZE NAMES arm-none-eabi-size)
+find_program(CMAKE_READELF NAMES arm-none-eabi-readelf) # handled by CMake in 3.16+
+
 set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx.ld)

--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -5,11 +5,6 @@ set(CMAKE_C_COMPILER arm-none-eabi-gcc CACHE PATH "Path to C compiler")
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++ CACHE PATH "Path to C++ compiler")
 
 set(CMAKE_SIZE arm-none-eabi-size CACHE PATH "Path to size tool")
-set(CMAKE_READELF arm-none-eabi-readelf CACHE PATH "Path to readelf tool")
-set(CMAKE_RANLIB arm-none-eabi-gcc-ranlib CACHE PATH "Path to ranlib")
-set(CMAKE_AR arm-none-eabi-gcc-ar CACHE PATH "Path to ar")
-set(CMAKE_OBJCOPY arm-none-eabi-objcopy CACHE PATH "Path to objcopy")
-set(CMAKE_LINKER arm-none-eabi-ld CACHE PATH "Path to linker")
 set(CMAKE_DFU "${CMAKE_CURRENT_LIST_DIR}/tools/dfu" CACHE PATH "Path to DFU builder")
 
 set(MCU_LINKER_SCRIPT STM32H750VBTx.ld)


### PR DESCRIPTION
CMake finds most of these for us as part of its compiler detection(https://github.com/Kitware/CMake/blob/v3.16.9/Modules/CMakeFindBinUtils.cmake#L112). Using find_program for the other two avoids a mix of full paths and names in the cache. 

Which helps if there's weird stuff going on with PATH... *looks at VS*