### PR TITLE
Link the firmware against the right stdlibs

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -91,7 +91,7 @@ endif()
 set(CMAKE_CXX_STANDARD_LIBRARIES_INIT "-nodefaultlibs -lstdc++_nano -lm -Wl,--start-group -lgcc -lc_nano -Wl,--end-group -Wl,--start-group -lgcc -lc_nano -lnosys -Wl,--end-group")
 
 set(PIC_STDLIBS "-L ${STDLIB_PATH}/pic")
-set(NONPIC_STDLIBS "-L ${STDLIB_PATH}/no-pic")
+set(NOPIC_STDLIBS "-L ${STDLIB_PATH}/no-pic")
 
 add_definitions(-DTARGET_32BLIT_HW)
 set(32BLIT_HW 1)


### PR DESCRIPTION
Toolchain used `NONPIC_STDLIBS`, CMakeLists used `NOPIC_STDLIBS`, resulting in the firmware using the system libraries. If you're using Ubuntu these are similar enough that this doesn't explode.