### PR TITLE
Add user_data field for Timer

### DIFF
--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -11,6 +11,7 @@ namespace blit {
     // uint32_t callback;                      // reference to Lua callback function (can be obtained via `ref = _G['function_name']`)
     
     TimerCallback callback = nullptr;
+    void *user_data = nullptr;
    
     uint32_t duration = 0;                  // how many milliseconds between callbacks
     uint32_t started = 0;                   // system time when timer started in milliseconds

--- a/32blit/engine/tweening.hpp
+++ b/32blit/engine/tweening.hpp
@@ -9,6 +9,7 @@ namespace blit {
   struct Tween {
     using TweenFunction = float (*)(uint32_t t, float b, float c, uint32_t d);
     TweenFunction function = nullptr;
+    void *user_data = nullptr;
 
     float from = 0.0f;
     float to = 1.0f;


### PR DESCRIPTION
This is used by 32blit-lua to store the Lua state and callback function reference.