### PR TITLE
Add python3-setuptools to apt line

### DIFF
--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -26,7 +26,7 @@ For 32Blit device builds:
 New enough versions of these exist in at least Debian "buster" and Ubuntu 20.04.
 
 ```
-sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip libsdl2-dev libsdl2-image-dev libsdl2-net-dev unzip
+sudo apt install git gcc g++ gcc-arm-none-eabi cmake make python3 python3-pip python3-setuptools libsdl2-dev libsdl2-image-dev libsdl2-net-dev unzip
 
 pip3 install 32blit
 ```

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -34,7 +34,7 @@ The following requirements enable cross-compile to 32Blit via ARM GCC:
 (These are similar to the [Linux requirements](Linux.md#prerequisites), see those for more details)
 
 ```
-sudo apt install gcc gcc-arm-none-eabi unzip cmake make python3 python3-pip
+sudo apt install gcc gcc-arm-none-eabi unzip cmake make python3 python3-pip python3-setuptools
 pip3 install 32blit construct bitstring
 ```
 


### PR DESCRIPTION
Small fix for an older issue. (#287)

This is only a "recommends" in Debian stable/Ubuntu LTS so may not get installed automatically.

(Didn't do anything about `sudo pip` as I'm a little against that...)