### PR TITLE
Timer/Tween improvements

### DIFF
--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -41,14 +41,12 @@ namespace blit {
     if(state == UNINITIALISED)
       timers.push_back(this);
 
-    // reset loop counter if we're restarting
-    if(state == STOPPED || state == FINISHED)
-      loop_count = 0;
-
     if(state == PAUSED)
       started = blit::now() - (paused - started); // Modify start time based on when timer was paused.
-    else
+    else {
       started = blit::now();
+      loop_count = 0;
+    }
 
     this->state = RUNNING;
   }

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -8,6 +8,10 @@ namespace blit {
 
   Timer::Timer() = default;
 
+  Timer::Timer(TimerCallback callback, uint32_t duration, int32_t loops) {
+    init(callback, duration, loops);
+  }
+
   Timer::~Timer() {
     for(auto it = timers.begin(); it != timers.end(); ++it) {
       if(*it == this) {

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -45,8 +45,22 @@ namespace blit {
     if(state == STOPPED || state == FINISHED)
       loops = orig_loops;
 
-    this->started = blit::now();
+    if(state == PAUSED)
+      started = blit::now() - (paused - started); // Modify start time based on when timer was paused.
+    else
+      started = blit::now();
+
     this->state = RUNNING;
+  }
+
+  /**
+   * Pause the timer.
+   */
+  void Timer::pause() {
+    if (state != RUNNING) return;
+
+    paused = blit::now();
+    state = PAUSED;
   }
 
   /**

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -31,7 +31,7 @@ namespace blit {
   void Timer::init(TimerCallback callback, uint32_t duration, int32_t loops) {
     this->callback = callback;
     this->duration = duration;
-    this->loops = orig_loops = loops;
+    this->loops = loops;
   }
 
   /**
@@ -43,7 +43,7 @@ namespace blit {
 
     // reset loop counter if we're restarting
     if(state == STOPPED || state == FINISHED)
-      loops = orig_loops;
+      loop_count = 0;
 
     if(state == PAUSED)
       started = blit::now() - (paused - started); // Modify start time based on when timer was paused.
@@ -86,9 +86,9 @@ namespace blit {
           }
           else
           {
-            t->loops--;
+            t->loop_count++;
             t->started = time;
-            if (t->loops == 0){
+            if (t->loop_count == t->loops){
               t->state = Timer::FINISHED;
             }
           }

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -31,7 +31,7 @@ namespace blit {
   void Timer::init(TimerCallback callback, uint32_t duration, int32_t loops) {
     this->callback = callback;
     this->duration = duration;
-    this->loops = loops;
+    this->loops = orig_loops = loops;
   }
 
   /**
@@ -40,6 +40,10 @@ namespace blit {
   void Timer::start() {
     if(state == UNINITIALISED)
       timers.push_back(this);
+
+    // reset loop counter if we're restarting
+    if(state == STOPPED || state == FINISHED)
+      loops = orig_loops;
 
     this->started = blit::now();
     this->state = RUNNING;

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -28,13 +28,15 @@ namespace blit {
     this->callback = callback;
     this->duration = duration;
     this->loops = loops;
-    timers.push_back(this);
   }
 
   /**
    * Start the timer.
    */
   void Timer::start() {
+    if(state == UNINITIALISED)
+      timers.push_back(this);
+
     this->started = blit::now();
     this->state = RUNNING;
   }
@@ -43,6 +45,8 @@ namespace blit {
    * Stop the running timer.
    */
   void Timer::stop() {
+    if(state == UNINITIALISED) return;
+
     this->state = STOPPED;
   }
 

--- a/32blit/engine/timer.cpp
+++ b/32blit/engine/timer.cpp
@@ -8,6 +8,15 @@ namespace blit {
 
   Timer::Timer() = default;
 
+  Timer::~Timer() {
+    for(auto it = timers.begin(); it != timers.end(); ++it) {
+      if(*it == this) {
+        timers.erase(it);
+        break;
+      }
+    }
+  }
+
   /**
    * Initialize the timer.
    *

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -13,7 +13,7 @@ namespace blit {
 
     uint32_t duration = 0;                  // how many milliseconds between callbacks
     uint32_t started = 0;                   // system time when timer started in milliseconds
-    int16_t loops = -1;                     // number of times to repeat timer (-1 == forever)
+    int32_t loops = -1, orig_loops = -1;    // number of times to repeat timer (-1 == forever)
     enum state {                            // state of the timer
       UNINITIALISED,
       STOPPED,

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -8,17 +8,15 @@ namespace blit {
   struct Timer {
     using TimerCallback = void (*)(Timer &timer);
 
-    // uint32_t callback;                      // reference to Lua callback function (can be obtained via `ref = _G['function_name']`)
-    
     TimerCallback callback = nullptr;
     void *user_data = nullptr;
-   
+
     uint32_t duration = 0;                  // how many milliseconds between callbacks
     uint32_t started = 0;                   // system time when timer started in milliseconds
     int16_t loops = -1;                     // number of times to repeat timer (-1 == forever)
-    enum state {                            // state of the timer 
-      STOPPED, 
-      RUNNING, 
+    enum state {                            // state of the timer
+      STOPPED,
+      RUNNING,
       PAUSED,
       FINISHED
     };
@@ -36,14 +34,5 @@ namespace blit {
     Timer();
   };
 
-  extern std::vector<Timer *> timers;
-
-  struct timer_event_t {
-
-  };
-
   extern void update_timers(uint32_t time);
-
-  //extern std::vector<timer *> timers;  
-
 }

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -9,7 +9,6 @@ namespace blit {
     using TimerCallback = std::function<void (Timer &timer)>;
 
     TimerCallback callback = nullptr;
-    void *user_data = nullptr;
 
     uint32_t duration = 0;                  // how many milliseconds between callbacks
     uint32_t started = 0;                   // system time when timer started in milliseconds

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -32,6 +32,7 @@ namespace blit {
     bool is_finished()  { return this->state == FINISHED; }
 
     Timer();
+    ~Timer();
   };
 
   extern void update_timers(uint32_t time);

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -13,6 +13,7 @@ namespace blit {
 
     uint32_t duration = 0;                  // how many milliseconds between callbacks
     uint32_t started = 0;                   // system time when timer started in milliseconds
+    uint32_t paused = 0;                    // time when timer was paused
     int32_t loops = -1, orig_loops = -1;    // number of times to repeat timer (-1 == forever)
     enum state {                            // state of the timer
       UNINITIALISED,
@@ -25,6 +26,7 @@ namespace blit {
 
     void init(TimerCallback callback, uint32_t duration, int32_t loops = -1);
     void start();
+    void pause();
     void stop();
 
     bool is_running()   { return this->state == RUNNING; }

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -6,7 +6,7 @@
 namespace blit {
 
   struct Timer {
-    using TimerCallback = void (*)(Timer &timer);
+    using TimerCallback = std::function<void (Timer &timer)>;
 
     TimerCallback callback = nullptr;
     void *user_data = nullptr;

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -15,12 +15,13 @@ namespace blit {
     uint32_t started = 0;                   // system time when timer started in milliseconds
     int16_t loops = -1;                     // number of times to repeat timer (-1 == forever)
     enum state {                            // state of the timer
+      UNINITIALISED,
       STOPPED,
       RUNNING,
       PAUSED,
       FINISHED
     };
-    uint8_t state = STOPPED;
+    uint8_t state = UNINITIALISED;
 
     void init(TimerCallback callback, uint32_t duration, int32_t loops = -1);
     void start();

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -14,7 +14,7 @@ namespace blit {
     uint32_t duration = 0;                  // how many milliseconds between callbacks
     uint32_t started = 0;                   // system time when timer started in milliseconds
     uint32_t paused = 0;                    // time when timer was paused
-    int32_t loops = -1, orig_loops = -1;    // number of times to repeat timer (-1 == forever)
+    int32_t loops = -1, loop_count = 0;     // number of times to repeat timer (-1 == forever)
     enum state {                            // state of the timer
       UNINITIALISED,
       STOPPED,

--- a/32blit/engine/timer.hpp
+++ b/32blit/engine/timer.hpp
@@ -33,6 +33,7 @@ namespace blit {
     bool is_finished()  { return this->state == FINISHED; }
 
     Timer();
+    Timer(TimerCallback callback, uint32_t duration, int32_t loops = -1);
     ~Timer();
   };
 

--- a/32blit/engine/tweening.cpp
+++ b/32blit/engine/tweening.cpp
@@ -10,6 +10,21 @@
 namespace blit {
   std::vector<Tween *> tweens;
 
+  Tween::Tween() = default;
+
+  Tween::Tween(TweenFunction function, float start, float end, uint32_t duration, int32_t loops) {
+    init(function, start, end, duration, loops);
+  }
+
+  Tween::~Tween() {
+    for(auto it = tweens.begin(); it != tweens.end(); ++it) {
+      if(*it == this) {
+        tweens.erase(it);
+        break;
+      }
+    }
+  }
+
   /**
    * Initialize the tween.
    *
@@ -26,23 +41,42 @@ namespace blit {
     this->to = to;
     this->duration = duration;
     this->loop_count = 0;
-    tweens.push_back(this);
   }
 
   /**
    * Start the tween.
    */
   void Tween::start() {
-    this->started = blit::now();
-    this->loop_count = 0;
+    if(state == UNINITIALISED)
+      tweens.push_back(this);
+
+    if(state == PAUSED) {
+      started = blit::now() - (paused - started); // Modify start time based on when tween was paused.
+    } else {
+      this->started = blit::now();
+      this->loop_count = 0;
+      this->value = this->from;
+    }
+
     this->state = RUNNING;
-    this->value = this->from;
+  }
+
+  /**
+   * Pause the tween.
+   */
+  void Tween::pause() {
+    if (state != RUNNING) return;
+
+    paused = blit::now();
+    state = PAUSED;
   }
 
   /**
    * Stop the running tween.
    */
   void Tween::stop() {
+    if(state == UNINITIALISED) return;
+
     this->state = STOPPED;
   }
 

--- a/32blit/engine/tweening.cpp
+++ b/32blit/engine/tweening.cpp
@@ -79,17 +79,17 @@ namespace blit {
   void update_tweens(uint32_t time) {
     for (auto tween : tweens) {
       if (tween->state == Tween::RUNNING){
-        uint32_t elapsed = blit::now() - tween->started;
+        uint32_t elapsed = time - tween->started;
         tween->value = tween->function(elapsed, tween->from, tween->to, tween->duration);
 
         if (elapsed >= tween->duration) {
           if(tween->loops == -1){
-            tween->started = blit::now();
+            tween->started = time;
           }
           else
           {
             tween->loop_count++;
-            tween->started = blit::now();
+            tween->started = time;
             if (tween->loop_count == tween->loops){
               tween->state = Tween::FINISHED;
             }

--- a/32blit/engine/tweening.hpp
+++ b/32blit/engine/tweening.hpp
@@ -7,7 +7,7 @@ namespace blit {
   const uint32_t LINEAR = 1UL << 0;
 
   struct Tween {
-    using TweenFunction = float (*)(uint32_t t, float b, float c, uint32_t d);
+    using TweenFunction = std::function<float(uint32_t t, float b, float c, uint32_t d)>;
     TweenFunction function = nullptr;
     void *user_data = nullptr;
 
@@ -19,23 +19,30 @@ namespace blit {
     int32_t loops = -1;
     int32_t loop_count = 0;
     uint32_t started = 0;
+    uint32_t paused = 0;                    // time when tween was paused
 
     enum state {
-      STOPPED, 
-      RUNNING, 
+      UNINITIALISED,
+      STOPPED,
+      RUNNING,
       PAUSED,
       FINISHED
     };
-    uint8_t state = STOPPED;
+    uint8_t state = UNINITIALISED;
 
     void init(TweenFunction function, float start, float end, uint32_t duration, int32_t loops = -1);
     void start();
+    void pause();
     void stop();
 
     bool is_running()   { return this->state == RUNNING; }
     bool is_paused()    { return this->state == PAUSED; }
     bool is_stopped()   { return this->state == STOPPED; }
     bool is_finished()  { return this->state == FINISHED; }
+
+    Tween();
+    Tween(TweenFunction function, float start, float end, uint32_t duration, int32_t loops = -1);
+    ~Tween();
   };
 
   extern std::vector<Tween *> tweens;

--- a/32blit/engine/tweening.hpp
+++ b/32blit/engine/tweening.hpp
@@ -9,7 +9,6 @@ namespace blit {
   struct Tween {
     using TweenFunction = std::function<float(uint32_t t, float b, float c, uint32_t d)>;
     TweenFunction function = nullptr;
-    void *user_data = nullptr;
 
     float from = 0.0f;
     float to = 1.0f;

--- a/examples/tween-demo/tween-demo.cpp
+++ b/examples/tween-demo/tween-demo.cpp
@@ -71,4 +71,11 @@ void update(uint32_t time_ms) {
     tween.function = tween_funcs[current_tween_func].func;
     tween.start();
   }
+
+  if(buttons.released & Button::A) {
+    if(tween.is_paused())
+      tween.start();
+    else
+      tween.pause();
+  }
 }


### PR DESCRIPTION
Fixes:
- Deleting a `Timer` or anything containing a timer causing a use-after-free.
- Restarting a non-infinite timer not resetting the loop count and turning it into an infinite timer
- Half implemented pause (#519)
- Makes the stored loop count the same size as the argument to `init` (int32 vs int16)

WIP because:
- Switched the function pointer to `std::function`, which makes the `user_data` pointer a bit redundant as you can use bind/lambdas to pass stuff in
- Moved most of `init` to the constructor, but didn't remove `init` because breakage
- Need to update `Tween`