### PR TITLE
Remove test code from logo example

### DIFF
--- a/examples/logo/logo.cpp
+++ b/examples/logo/logo.cpp
@@ -5,7 +5,6 @@
 #include <cstdlib>
 
 #include "logo.hpp"
-#include "engine/version.hpp"
 
 using namespace blit;
 
@@ -171,9 +170,7 @@ void render(uint32_t time) {
 
   }
 
-  char buf[100];
-  snprintf(buf, 100, "Ver: %s Date: %s\n", blit::get_version_string(), blit::get_build_date());
-  blit::screen.text(buf, blit::minimal_font, blit::Point(blit::screen.bounds.w, blit::screen.bounds.h), true, blit::TextAlign::bottom_right);
+
 }
 
 void update(uint32_t time) {


### PR DESCRIPTION
This reverts commit 725a7ee1071687f9337e09bec2397d48e7153066.

Not sure how that got there.