### PR TITLE
Do a full scan_flash before launching after flash

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -1079,9 +1079,8 @@ void FlashLoader::handle_data_end(bool success) {
           // if we just erased the thing we were running, we need to reset to not crash
           // also need to do firmware updates immediately
 
-          // update the launcher offset
-          if(strcmp(meta.category, "launcher") == 0)
-            launcher_offset = flash_start_offset;
+          // update the launcher offset and any handlers
+          scan_flash();
 
           blit_switch_execution(flash_start_offset, true);
           return;


### PR DESCRIPTION
Fixes flashing something with file associations while it's running. (It would try to launch the old one the next time you opened a file)

I was trying to avoid work by only setting the launcher offset instead of this... resulting in this fun corner-case.