### PR TITLE
Bump Emscripten version

### DIFF
--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: emcmake cmake $GITHUB_WORKSPACE -D32BLIT_DIR=$GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: emcmake cmake $GITHUB_WORKSPACE -D32BLIT_DIR=$GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG"
 
     # Problem matching
     - uses: ammaraskar/gcc-problem-matcher@master

--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  EM_VERSION: 2.0.4
+  EM_VERSION: 2.0.18
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:


### PR DESCRIPTION
Should fix the "unexpected hash" errors caused by https://dl.bintray.com/homebrew/mirror/jpeg-9c.tar.gz returning "Forbidden!" again...

TODO: boilerplate too