### PR TITLE
Check that calling the tools didn't fail

### DIFF
--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -24,7 +24,7 @@ if (NOT DEFINED BLIT_ONCE)
 	if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 		set(CMAKE_BUILD_TYPE "Release")
 	endif()
-	
+
 	if(WIN32)
 		add_definitions("-DWIN32")
 	endif()
@@ -36,7 +36,14 @@ if (NOT DEFINED BLIT_ONCE)
 		set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
 
 		# get the inputs/outputs for the asset tool (at configure time)
-		execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake)
+		execute_process(
+		    COMMAND ${PYTHON_EXECUTABLE} -m ttblit --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake
+            RESULT_VARIABLE TOOL_RESULT
+		)
+		if(${TOOL_RESULT})
+		    message(FATAL_ERROR "Reading asset config failed!\n")
+		endif()
+
 		include(${CMAKE_CURRENT_BINARY_DIR}/assets.cmake)
 
 		# do asset packing (at build time)

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -237,7 +237,14 @@ function(blit_metadata TARGET FILE)
 	set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${FILE})
 
 	# parse the metadata to variables
-	execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
+	execute_process(
+		COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+		RESULT_VARIABLE TOOL_RESULT
+	)
+	if(${TOOL_RESULT})
+		message(FATAL_ERROR "Reading metadata config failed!\n")
+	endif()
+
 	include(${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
 
 	if(APPLE)

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -56,7 +56,14 @@ function(blit_metadata TARGET FILE)
 	set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${FILE})
 
 	# get the inputs/outputs for the asset tool (at configure time)
-	execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
+	execute_process(
+		COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+		RESULT_VARIABLE TOOL_RESULT
+	)
+	if(${TOOL_RESULT})
+		message(FATAL_ERROR "Reading metadata config failed!\n")
+	endif()
+
 	include(${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
 
 	if(${CMAKE_VERSION} VERSION_LESS "3.15.0")


### PR DESCRIPTION
If the tool does fail we'll either fail to include the generated file on the next line, or ignore the error and continue using stale config.

Error you get without this if metadata/assets.yml is missing:
```
...
FileNotFoundError: [Errno 2] No such file or directory: '/batt/repos/.../metadata.yml'
CMake Error at /batt/32blit/32blit-stm32/executable.cmake:60 (include):
  include could not find load file:

    /batt/repos/.../build/metadata.cmake
Call Stack (most recent call first):
  CMakeLists.txt:6 (blit_metadata)
```