### PR TITLE
Fix corner-case off-by-one in RLE sprite unpacking

### DIFF
--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -675,6 +675,7 @@ namespace blit {
     if (format == PixelFormat::P) {
       // load paletted
       uint8_t *pdest = (uint8_t *)ret->data;
+      auto dest_end = pdest + needed_size;
 
       if(is_rle) {
         int parse_state = 0;
@@ -711,6 +712,10 @@ namespace blit {
                   bit = 0; col = 0;
                   parse_state = 0;
                   count = 0;
+                  
+                  // done, skip any remaining padding
+                  if(pdest == dest_end)
+                    parse_state = 3;
                 }
                 break;
             }


### PR DESCRIPTION
It's possible that there's enough padding at the end of the data to encode an extra 0 entry if `bits_per_pixel` is < 7... and one of my sprites in blit kart happens to cause that.

Might be possible to trigger something similar with non-RLE packed data too, but haven't checked.

(Probably wouldn't have caught this if I didn't have ASan enabled!)
```
=================================================================
==579178==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62900009a200 at pc 0x555fd9cef633 bp 0x7faffb824ba0 sp 0x7faffb824b90
WRITE of size 1 at 0x62900009a200 thread T3 (Loop)
    #0 0x555fd9cef632 in blit::Surface::load_from_packed(blit::File&, unsigned char*, unsigned long, bool) /home/daftfreak/programs/32blit-beta/32blit/graphics/surface.cpp:710
    #1 0x555fd9ce6548 in blit::Surface::load(blit::packed_image const*, unsigned char*, unsigned long) /home/daftfreak/programs/32blit-beta/32blit/graphics/surface.cpp:70
    #2 0x555fd9c7ffa6 in blit::Surface::load(unsigned char const*) /home/daftfreak/programs/32blit-beta/32blit/graphics/surface.hpp:129
    #3 0x555fd9ca8fd9 in Track::Track(TrackInfo const&) ../track.cpp:147
    #4 0x555fd9cb0844 in TrackSelect::update(unsigned int) ../track-select.cpp:49
    #5 0x555fd9c7347d in Game::update(unsigned int) ../game.cpp:19
    #6 0x555fd9c73691 in update(unsigned int) ../game.cpp:81
    #7 0x555fd9cd37ff in blit::tick(unsigned int) /home/daftfreak/programs/32blit-beta/32blit/engine/engine.cpp:96
    #8 0x555fd9cc5c53 in System::loop() /home/daftfreak/programs/32blit-beta/32blit-sdl/System.cpp:271
    #9 0x555fd9cc572e in System::update_thread() /home/daftfreak/programs/32blit-beta/32blit-sdl/System.cpp:252
    #10 0x555fd9cc3b19 in system_loop_thread /home/daftfreak/programs/32blit-beta/32blit-sdl/System.cpp:139
    #11 0x7fb01c006682 in SDL_RunThread src/thread/SDL_thread.c:275
    #12 0x7fb01c08df8c in RunThread src/thread/pthread/SDL_systhread.c:78
    #13 0x7fb019dd144f in start_thread nptl/pthread_create.c:473
    #14 0x7fb019f08d52 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x117d52)

0x62900009a200 is located 0 bytes to the right of 16384-byte region [0x629000096200,0x62900009a200)
allocated by thread T3 (Loop) here:
    #0 0x7fb01c1be717 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x555fd9cef034 in blit::Surface::load_from_packed(blit::File&, unsigned char*, unsigned long, bool) /home/daftfreak/programs/32blit-beta/32blit/graphics/surface.cpp:661
    #2 0x555fd9ce6548 in blit::Surface::load(blit::packed_image const*, unsigned char*, unsigned long) /home/daftfreak/programs/32blit-beta/32blit/graphics/surface.cpp:70
    #3 0x555fd9c7ffa6 in blit::Surface::load(unsigned char const*) /home/daftfreak/programs/32blit-beta/32blit/graphics/surface.hpp:129
    #4 0x555fd9ca8fd9 in Track::Track(TrackInfo const&) ../track.cpp:147
    #5 0x555fd9cb0844 in TrackSelect::update(unsigned int) ../track-select.cpp:49
    #6 0x555fd9c7347d in Game::update(unsigned int) ../game.cpp:19
    #7 0x555fd9c73691 in update(unsigned int) ../game.cpp:81
    #8 0x555fd9cd37ff in blit::tick(unsigned int) /home/daftfreak/programs/32blit-beta/32blit/engine/engine.cpp:96
    #9 0x555fd9cc5c53 in System::loop() /home/daftfreak/programs/32blit-beta/32blit-sdl/System.cpp:271
    #10 0x555fd9cc572e in System::update_thread() /home/daftfreak/programs/32blit-beta/32blit-sdl/System.cpp:252
    #11 0x555fd9cc3b19 in system_loop_thread /home/daftfreak/programs/32blit-beta/32blit-sdl/System.cpp:139
    #12 0x7fb01c006682 in SDL_RunThread src/thread/SDL_thread.c:275

Thread T3 (Loop) created by T0 here:
    #0 0x7fb01c1606d5 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x7fb01c08e008 in SDL_SYS_CreateThread src/thread/pthread/SDL_systhread.c:119
...
```