### PR TITLE
Rix reading battery fault status

### DIFF
--- a/32blit-stm32/Inc/32blit_battery.hpp
+++ b/32blit-stm32/Inc/32blit_battery.hpp
@@ -23,13 +23,13 @@ namespace battery {
   };
 
   struct BatteryInformation {
-      BatteryChargeStatus charge_status;
-      const char * charge_text;
+    BatteryChargeStatus charge_status;
+    BatteryVbusStatus vbus_status;
 
-      BatteryVbusStatus vbus_status;
-      const char * vbus_text;
+    const char * charge_text;
+    const char * vbus_text;
 
-      float voltage;
+    float voltage;
   };
 
   // Battery information

--- a/32blit-stm32/Inc/i2c-bq24295.h
+++ b/32blit-stm32/Inc/i2c-bq24295.h
@@ -30,9 +30,6 @@ extern "C" {
 #endif
 
 extern bool bq24295_init(I2C_HandleTypeDef *i2c_port);
-extern uint16_t bq24295_get_statusfault(I2C_HandleTypeDef *i2c_port);
-extern uint8_t bq24295_get_status(I2C_HandleTypeDef *i2c_port);
-extern uint8_t bq24295_get_fault(I2C_HandleTypeDef *i2c_port);
 extern void bq24295_enable_shipping_mode(I2C_HandleTypeDef *i2c_port);
 extern void bq24295_disable_battery_fault_int(I2C_HandleTypeDef *i2c_port);
 

--- a/32blit-stm32/Src/i2c-bq24295.c
+++ b/32blit-stm32/Src/i2c-bq24295.c
@@ -2,7 +2,6 @@
 
 static void _i2c_send_8(I2C_HandleTypeDef *i2c_port, uint8_t address, uint8_t reg, uint8_t data);
 static uint8_t _i2c_recv_8(I2C_HandleTypeDef *i2c_port, uint8_t address, uint8_t reg);
-static uint16_t _i2c_recv_16(I2C_HandleTypeDef *i2c_port, uint16_t address, uint8_t reg );
 
 bool bq24295_init(I2C_HandleTypeDef *i2c_port) {
     uint8_t chip_id = _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_ID_REGISTER);
@@ -20,18 +19,6 @@ bool bq24295_init(I2C_HandleTypeDef *i2c_port) {
         return true;
     }
     return false;
-}
-
-uint16_t bq24295_get_statusfault(I2C_HandleTypeDef *i2c_port) {
-    return _i2c_recv_16(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_SYS_STATUS_REGISTER);
-}
-
-uint8_t bq24295_get_status(I2C_HandleTypeDef *i2c_port) {
-    return _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_SYS_STATUS_REGISTER);
-}
-
-uint8_t bq24295_get_fault(I2C_HandleTypeDef *i2c_port) {
-    return _i2c_recv_8(i2c_port, BQ24295_DEVICE_ADDRESS, BQ24295_SYS_FAULT_REGISTER);
 }
 
 void bq24295_disable_battery_fault_int(I2C_HandleTypeDef *i2c_port){
@@ -56,8 +43,8 @@ void bq24295_enable_shipping_mode(I2C_HandleTypeDef *i2c_port){
 
 static uint8_t _i2c_recv_8(I2C_HandleTypeDef *i2c_port,  uint8_t address, uint8_t reg ){
     uint8_t result;
-    HAL_I2C_Master_Transmit(i2c_port, address, &reg, 1, HAL_TIMEOUT);  
-    HAL_Delay(1); 
+    HAL_I2C_Master_Transmit(i2c_port, address, &reg, 1, HAL_TIMEOUT);
+    HAL_Delay(1);
     HAL_I2C_Master_Receive(i2c_port, address, &result, 1, HAL_TIMEOUT);
     return result;
 }
@@ -67,14 +54,4 @@ static void _i2c_send_8(I2C_HandleTypeDef *i2c_port, uint8_t address, uint8_t re
     data_buffer[0] = reg;
     data_buffer[1] = data;
     HAL_I2C_Master_Transmit(i2c_port, address, &data_buffer[0], 2, HAL_TIMEOUT);
-}
-
-static uint16_t _i2c_recv_16(I2C_HandleTypeDef *i2c_port, uint16_t address, uint8_t reg ){
-  uint8_t receive_buffer[2];
-
-  HAL_I2C_Master_Transmit(i2c_port, address, &reg, 1, HAL_TIMEOUT); //set register pointer
-  HAL_Delay(1);
-  HAL_I2C_Master_Receive(i2c_port, address, &receive_buffer[0], 2, HAL_TIMEOUT); //read two bytes from register
-
-  return (uint16_t)(receive_buffer[0] << 8) + receive_buffer [1]; //combine MSB LSB
 }


### PR DESCRIPTION
Attempting to read the fault register and the status register in one read would result in the fault register always reading as 0. We're still not doing anything with the fault status, but at least it reads correctly now.


Also some cleanup.