### PR TITLE
Skip time spent with the menu open

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -410,6 +410,8 @@ void blit_init() {
 
     blit::api.get_metadata = ::get_metadata;
 
+    blit::api.tick_function_changed = false;
+
   display::init();
 
   multiplayer::init();
@@ -484,6 +486,7 @@ void blit_menu() {
     if (user_tick && !user_code_disabled) {
       // user code was running
       do_tick = user_tick;
+      api.tick_function_changed = true;
       blit::render = user_render;
     } else {
       blit::update = ::update;
@@ -504,6 +507,7 @@ void blit_menu() {
     blit::update = blit_menu_update;
     blit::render = blit_menu_render;
     do_tick = blit::tick;
+    api.tick_function_changed = true;
 
     if(screen.format == PixelFormat::P) {
       memcpy(menu_saved_colours, screen.palette, num_menu_colours * sizeof(Pen));
@@ -721,6 +725,7 @@ bool blit_switch_execution(uint32_t address, bool force_game)
     blit::render = ::render;
     blit::update = ::update;
     do_tick = blit::tick;
+    api.tick_function_changed = true;
 
     cached_file_in_tmp = false;
     close_open_files();
@@ -846,6 +851,7 @@ void blit_enable_user_code() {
     return;
 
   do_tick = user_tick;
+  api.tick_function_changed = true;
   blit::render = user_render;
   user_code_disabled = false;
   sound::enabled = true;
@@ -856,6 +862,7 @@ void blit_disable_user_code() {
     return;
 
   do_tick = blit::tick;
+  api.tick_function_changed = true;
   blit::render = ::render;
   sound::enabled = false;
   user_code_disabled = true;

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -84,6 +84,8 @@ namespace blit {
     void (*tmp_file_closed)(const uint8_t *ptr);
 
     GameMetadata (*get_metadata)();
+
+    bool tick_function_changed;
   };
   #pragma pack(pop)
 

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -79,6 +79,13 @@ namespace blit {
       last_tick_time = time;
     }
 
+    bool was_menu_open = (last_state & Button::HOME) && !(api.buttons.state & Button::HOME);
+
+    // skip time spent in the menu
+    if (was_menu_open && time - last_tick_time > 10) {
+      last_tick_time = time;
+    }
+
     // update timers
     update_timers(time);
     update_tweens(time);

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -82,10 +82,8 @@ namespace blit {
       last_tick_time = time;
     }
 
-    bool was_menu_open = (last_state & Button::HOME) && !(api.buttons.state & Button::HOME);
-
-    // skip time spent in the menu
-    if (was_menu_open && time - last_tick_time > 10) {
+    // skip time where this wasn't the active tick function (menu/game switches)
+    if (api.tick_function_changed) {
       auto skipped_time = time - last_tick_time;
       last_tick_time = time;
 
@@ -98,6 +96,8 @@ namespace blit {
         tween->started += skipped_time;
         tween->paused += skipped_time;
       }
+
+      api.tick_function_changed = false;
     }
 
     // update timers

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -74,6 +74,9 @@ namespace blit {
   static uint32_t last_tick_time = 0;
   static uint32_t last_state = 0;
 
+  extern std::vector<Timer *> timers;
+  extern std::vector<Tween *> tweens;
+
   int tick(uint32_t time) {
     if (last_tick_time == 0) {
       last_tick_time = time;
@@ -83,7 +86,18 @@ namespace blit {
 
     // skip time spent in the menu
     if (was_menu_open && time - last_tick_time > 10) {
+      auto skipped_time = time - last_tick_time;
       last_tick_time = time;
+
+      for (auto &timer : timers) {
+        timer->started += skipped_time;
+        timer->paused += skipped_time;
+      }
+
+      for (auto &tween : tweens) {
+        tween->started += skipped_time;
+        tween->paused += skipped_time;
+      }
     }
 
     // update timers


### PR DESCRIPTION
This avoids the issue where if you open the menu for a while and close it the game appears to hang/skip forward as it gets a huge number of `update` calls. (The same thing could happen to the menu, but it doesn't do much in update so was a lot harder to notice)

Also skips "menu time" for timers/tweens (tested with tween-demo). Didn't increase the API version despite adding a new field as nothing breaks with a mismatch (may sometimes trigger the skip code incorrectly, but only once and at the start of the game where it wouldn't call `update` anyway).


(This has been broken since 0b260b43b7ab37067746d9cbc8764734d67535ff)