### PR TITLE
Remove "Exit Game" from fw menu in Launcher

### DIFF
--- a/32blit-stm32/Src/SystemMenu/firmware_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/firmware_menu.cpp
@@ -47,14 +47,14 @@ static Menu::Item firmware_menu_items[] {
     {BACKLIGHT, "Backlight"},
     {VOLUME, "Volume"},
     {SCREENSHOT, "Take Screenshot"},
-    {Menu::Separator,nullptr},
+    {Menu::Separator, nullptr},
     {CONNECTIVITY, "Connectivity >"},
-    {Menu::Separator,nullptr},
+    {Menu::Separator, nullptr},
     {BATTERY_INFO, "Battery info >"},
-    {Menu::Separator,nullptr},
-    {ABOUT,"About 32blit >"},
+    {Menu::Separator, nullptr},
+    {ABOUT, "About 32blit >"},
     {POWER_OFF, "Power Off"},
-    {SWITCH_EXE, ""}, // label depends on if a game is running
+    {SWITCH_EXE, nullptr}, // label depends on if a game is running
 };
 
 //
@@ -65,7 +65,8 @@ void FirmwareMenu::prepare() {
   for(int i = 0; i < num_items; ++i ) {
     auto &item = const_cast<Item *>(items)[i];
     if(item.id == SWITCH_EXE) {
-      item.label = blit_user_code_running() ? "Exit Game" : "Launch Game";
+      auto metadata = get_metadata();
+      item.label = strcmp(metadata.category, "launcher") == 0 ? "Restart Launcher" : "Exit Game";
       break;
     }
   }

--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -65,7 +65,9 @@ protected:
           render_item(item, y, i);
         }
 
-        y += item_h + item_spacing;
+        if(item.label != nullptr || item.id == Menu::Separator) {
+          y += item_h + item_spacing;
+        }
       }
 
       screen.clip = old_clip;


### PR DESCRIPTION
If the running executable category is "launcher" this will hide the "Exit Game" menu item, since we're not in a game anyway.

Additionally moves SystemMenu from "32blit-stm32" to "firmware" where it belongs. (Though, to be fair, the line between the HAL and the firmware is... hazy)