### PR TITLE
Non-pico patches from the pico branch

### DIFF
--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -58,7 +58,7 @@ if (NOT DEFINED BLIT_ONCE)
 		target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 	endfunction()
 
-	if (${CMAKE_SYSTEM_NAME} STREQUAL Generic)
+	if (32BLIT_HW)
 		set(FLASH_PORT "AUTO" CACHE STRING "Port to use for flash")
 
 		include(${CMAKE_CURRENT_LIST_DIR}/32blit-stm32/executable.cmake)

--- a/32blit-stm32/Middlewares/ST/STM32_USB_Host_Library/Class/CDC/Src/usbh_cdc.c
+++ b/32blit-stm32/Middlewares/ST/STM32_USB_Host_Library/Class/CDC/Src/usbh_cdc.c
@@ -158,6 +158,13 @@ static USBH_StatusTypeDef USBH_CDC_InterfaceInit(USBH_HandleTypeDef *phost)
   interface = USBH_FindInterface(phost, COMMUNICATION_INTERFACE_CLASS_CODE,
                                  ABSTRACT_CONTROL_MODEL, COMMON_AT_COMMAND);
 
+  // retry with the "non-specific" protocol
+  if ((interface == 0xFFU) || (interface >= USBH_MAX_NUM_INTERFACES))
+  {
+    interface = USBH_FindInterface(phost, COMMUNICATION_INTERFACE_CLASS_CODE,
+                                   ABSTRACT_CONTROL_MODEL, NO_CLASS_SPECIFIC_PROTOCOL_CODE);
+  }
+
   if ((interface == 0xFFU) || (interface >= USBH_MAX_NUM_INTERFACES)) /* No Valid Interface */
   {
     USBH_DbgLog("Cannot Find the interface for Communication Interface Class.", phost->pActiveClass->Name);

--- a/32blit/graphics/color.cpp
+++ b/32blit/graphics/color.cpp
@@ -16,24 +16,21 @@ namespace blit {
    * \return Pen colour.
    */
   Pen hsv_to_rgba(float h, float s, float v) {
-    Pen res(0, 0, 0, 255);
-
-    uint8_t i = uint8_t(h * 6);
+    int i = int(h * 6);
     float f = h * 6 - i;
     float p = v * (1 - s);
     float q = v * (1 - f * s);
     float t = v * (1 - (1 - f) * s);
 
     switch (i % 6) {
-    case 0: res = Pen(v, t, p); break;
-    case 1: res = Pen(q, v, p); break;
-    case 2: res = Pen(p, v, t); break;
-    case 3: res = Pen(p, q, v); break;
-    case 4: res = Pen(t, p, v); break;
-    case 5: res = Pen(v, p, q); break;
+    default: //avoid warning
+    case 0: return Pen(v, t, p);
+    case 1: return Pen(q, v, p);
+    case 2: return Pen(p, v, t);
+    case 3: return Pen(p, q, v);
+    case 4: return Pen(t, p, v);
+    case 5: return Pen(v, p, q);
     }
-
-    return res;
   }
 
-}  
+}

--- a/32blit/graphics/color.cpp
+++ b/32blit/graphics/color.cpp
@@ -18,18 +18,22 @@ namespace blit {
   Pen hsv_to_rgba(float h, float s, float v) {
     int i = int(h * 6);
     float f = h * 6 - i;
-    float p = v * (1 - s);
-    float q = v * (1 - f * s);
-    float t = v * (1 - (1 - f) * s);
+
+    v = v * 255.0f;
+    uint8_t bv = uint8_t(v);
+
+    auto p = uint8_t(v * (1 - s));
+    auto q = uint8_t(v * (1 - f * s));
+    auto t = uint8_t(v * (1 - (1 - f) * s));
 
     switch (i % 6) {
-    default: //avoid warning
-    case 0: return Pen(v, t, p);
-    case 1: return Pen(q, v, p);
-    case 2: return Pen(p, v, t);
-    case 3: return Pen(p, q, v);
-    case 4: return Pen(t, p, v);
-    case 5: return Pen(v, p, q);
+    default:
+    case 0: return Pen(bv, t, p);
+    case 1: return Pen(q, bv, p);
+    case 2: return Pen(p, bv, t);
+    case 3: return Pen(p, q, bv);
+    case 4: return Pen(t, p, bv);
+    case 5: return Pen(bv, p, q);
     }
   }
 

--- a/32blit/graphics/color.cpp
+++ b/32blit/graphics/color.cpp
@@ -20,11 +20,15 @@ namespace blit {
     float f = h * 6 - i;
 
     v = v * 255.0f;
-    uint8_t bv = uint8_t(v);
 
-    auto p = uint8_t(v * (1 - s));
-    auto q = uint8_t(v * (1 - f * s));
-    auto t = uint8_t(v * (1 - (1 - f) * s));
+    float sv = s * v;
+    float fsv = f * sv;
+
+    auto p = uint8_t(-sv + v);
+    auto q = uint8_t(-fsv + v);
+    auto t = uint8_t(fsv - sv + v);
+
+    uint8_t bv = uint8_t(v);
 
     switch (i % 6) {
     default:

--- a/32blit/graphics/primitive.cpp
+++ b/32blit/graphics/primitive.cpp
@@ -28,6 +28,11 @@ namespace blit {
 
     uint32_t o = offset(cr);
 
+    if(cr.x == 0 && cr.w == bounds.w) {
+      pbf(&pen, this, o, cr.w * cr.h);
+      return;
+    }
+
     for (uint8_t y = cr.y; y < cr.y + cr.h; y++) {
       pbf(&pen, this, o, cr.w);
       o += bounds.w;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_subdirectory(examples)
 
 add_subdirectory(launcher-shared)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL Generic)
+if(32BLIT_HW)
     add_subdirectory(32blit-stm32)
     add_subdirectory(firmware)
     add_subdirectory(firmware-update)

--- a/examples/logo/logo.cpp
+++ b/examples/logo/logo.cpp
@@ -78,7 +78,7 @@ void render(uint32_t time) {
   float duration = 2.0f;
 
   ts += dir;
-  if (ts > 4.0f) {     
+  if (ts > 4.0f) {
     dir *= -1;
     ts = 1.0f;
   }
@@ -96,7 +96,7 @@ void render(uint32_t time) {
   float half_scale = scale / 2.0f + 0.5f;
   Mat4 r = Mat4::rotation(td * 250.0f, Vec3(0, 1, 0));
   Mat4 s = Mat4::scale(Vec3(scale, scale, scale));
-  Mat4 t = Mat4::translation(Vec3(80, 60, 0));
+  Mat4 t = Mat4::translation(Vec3(screen.bounds.w / 2, screen.bounds.h / 2, 0));
 
   for (int i = 0; i < 63; i++) {
     LogoParticle pc = particles[i];

--- a/examples/particle/particle.cpp
+++ b/examples/particle/particle.cpp
@@ -84,7 +84,7 @@ void smoke(uint32_t time_ms) {
     }
   }
 
-  
+
   last_time_ms = time_ms;
 };
 
@@ -138,7 +138,7 @@ void spark(uint32_t time_ms) {
 
     }
   }
-  
+
   last_time_ms = time_ms;
 };
 
@@ -172,7 +172,7 @@ void rain(uint32_t time_ms) {
     if (p.generated) {
       p.vel += gravity;
       p.pos += p.vel * td;
-      
+
       int floor = -3;
       if (p.pos.x > 20 && p.pos.x < 46)
         floor = -33;
@@ -206,7 +206,7 @@ void rain(uint32_t time_ms) {
 
 
 
-Particle* generate_basic_rain() {  
+Particle* generate_basic_rain() {
   return new Particle(
     Vec2((std::rand() % 120) + 100, 0),
     Vec2(0, 100)
@@ -226,16 +226,7 @@ void render_basic_rain() {
   }
 }
 
-uint32_t prev_buttons = blit::buttons;
-
 void render(uint32_t time_ms) {
-  if ((blit::buttons ^ prev_buttons) & blit::Button::A) {
-      blit::set_screen_mode(blit::lores);
-  }
-  else if ((blit::buttons ^ prev_buttons) & blit::Button::B) {
-      blit::set_screen_mode(blit::hires);
-  }
-  prev_buttons = blit::buttons;
 
   screen.pen = Pen(0, 0, 0, 255);
   screen.clear();
@@ -244,7 +235,7 @@ void render(uint32_t time_ms) {
 
   uint32_t ms_start = now();
   spark(time_ms);
-  smoke(time_ms); 
+  smoke(time_ms);
   rain(time_ms);
   //render_basic_rain();
   uint32_t ms_end = now();
@@ -256,7 +247,7 @@ void render(uint32_t time_ms) {
   screen.pen = Pen(0, 0, 0);
   screen.text("Rain demo", minimal_font, Point(5, 4));
 
- /* screen.pen = Pen(255, 255, 255);  
+ /* screen.pen = Pen(255, 255, 255);
   screen.text("Smoke:", minimal_font, point(10, 20));
   screen.text("Sparks:", minimal_font, point(120, 20));
   screen.text("Rain:", minimal_font, point(220, 20));  */
@@ -284,5 +275,11 @@ void update(uint32_t time_ms) {
 
   if (pressed(Button::DPAD_LEFT)) {
     g.rotate(0.1f);
+  }
+
+  if (blit::buttons.released & blit::Button::A) {
+    blit::set_screen_mode(blit::lores);
+  } else if (blit::buttons.released & blit::Button::B) {
+    blit::set_screen_mode(blit::hires);
   }
 }


### PR DESCRIPTION
An assortment of patches from the pico branch that aren't really pico related.

- A few example changes
- Small optimisations that are more noticeable on the pico (saves ~20ms in `hsv_to_rgb` there, the examples that do that per-pixel are still slow though)
- Half-working CDC host with TinyUSB-based device (will connect and receive, sending from the host hangs though.)