### PR TITLE
Fix SDL get_metadata description

### DIFF
--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -101,7 +101,7 @@ static blit::GameMetadata get_metadata() {
 
   ret.title = metadata_title;
   ret.author = metadata_author;
-  ret.description = metadata_author;
+  ret.description = metadata_description;
   ret.version = metadata_version;
   ret.url = metadata_url;
   ret.category = metadata_category;


### PR DESCRIPTION
Oops.

Happened to notice while ~~completely breaking~~ tweaking "the cupboard".