### PR TITLE
Set image-rendering on Emscripten canvas

### DIFF
--- a/32blit-sdl/emscripten-shell.html
+++ b/32blit-sdl/emscripten-shell.html
@@ -9,7 +9,12 @@
 
       div.emscripten { text-align: center; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; background-color: black; }
+      canvas.emscripten {
+        border: 0px none;
+        background-color: black;
+        image-rendering: pixelated;
+        image-rendering: crisp-edges;
+      }
 
       .spinner {
         height: 50px;


### PR DESCRIPTION
Avoids blurriness with hidpi screens. The shell used for the example browser already did this. (Specified twice for browser support reasons)