### PR TITLE
Pico tweaks

### DIFF
--- a/32blit-pico/config.h
+++ b/32blit-pico/config.h
@@ -5,6 +5,14 @@
 #define ALLOW_HIRES 1
 #endif
 
+#ifndef ST7789_WIDTH
+#define ST7789_WIDTH 240
+#endif
+
+#ifndef ST7789_HEIGHT
+#define ST7789_HEIGHT 240
+#endif
+
 #ifndef OVERCLOCK_250
 #define OVERCLOCK_250 1
 #endif

--- a/32blit-pico/input.cpp
+++ b/32blit-pico/input.cpp
@@ -2,6 +2,8 @@
 
 #include "hardware/gpio.h"
 
+#include "pico/binary_info.h"
+
 #include "engine/api_private.hpp"
 #include "engine/input.hpp"
 
@@ -53,6 +55,17 @@ void init_input() {
   init_button(ButtonIO::B);
   init_button(ButtonIO::X);
   init_button(ButtonIO::Y);
+
+  #define BUTTON_DECL(btn) bi_decl(bi_1pin_with_name(static_cast<int>(ButtonIO::btn), #btn" Button"));
+  BUTTON_DECL(UP)
+  BUTTON_DECL(DOWN)
+  BUTTON_DECL(LEFT)
+  BUTTON_DECL(RIGHT)
+  BUTTON_DECL(A)
+  BUTTON_DECL(B)
+  BUTTON_DECL(X)
+  BUTTON_DECL(Y)
+  #undef BUTTON_DECL
 #endif
 }
 

--- a/32blit-pico/led.cpp
+++ b/32blit-pico/led.cpp
@@ -4,6 +4,7 @@
 
 #include "hardware/gpio.h"
 #include "hardware/pwm.h"
+#include "pico/binary_info.h"
 
 #include "engine/api_private.hpp"
 
@@ -20,6 +21,10 @@ void init_led() {
     pwm_init(pwm_gpio_to_slice_num(pin), &cfg, true);
     gpio_set_function(pin, GPIO_FUNC_PWM);
   }
+
+  bi_decl(bi_1pin_with_name(led_pins[0], "Red LED"));
+  bi_decl(bi_1pin_with_name(led_pins[1], "Green LED"));
+  bi_decl(bi_1pin_with_name(led_pins[2], "Blue LED"));
 #endif
 }
 

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -26,14 +26,16 @@
 using namespace blit;
 
 #ifdef DISPLAY_ST7789
+static const int lores_page_size = (ST7789_WIDTH / 2) * (ST7789_HEIGHT / 2) * 2;
+
 #if ALLOW_HIRES
-uint8_t screen_fb[240 * 240 * 2];
+uint8_t screen_fb[ST7789_WIDTH * ST7789_HEIGHT * 2];
 #else
-uint8_t screen_fb[120 * 120 * 2 * 2]; // double-buffered
+uint8_t screen_fb[lores_page_size * 2]; // double-buffered
 #endif
 
-static Surface lores_screen(screen_fb, PixelFormat::RGB565, Size(120, 120));
-static Surface hires_screen(screen_fb, PixelFormat::RGB565, Size(240, 240));
+static Surface lores_screen(screen_fb, PixelFormat::RGB565, Size(ST7789_WIDTH / 2, ST7789_HEIGHT / 2));
+static Surface hires_screen(screen_fb, PixelFormat::RGB565, Size(ST7789_WIDTH, ST7789_HEIGHT));
 //static Surface hires_palette_screen(screen_fb, PixelFormat::P, Size(320, 240));
 #elif defined(DISPLAY_SCANVIDEO)
 uint8_t screen_fb[160 * 120 * 4];
@@ -44,9 +46,11 @@ static blit::AudioChannel channels[CHANNEL_COUNT];
 
 #ifdef DISPLAY_ST7789
 #ifdef PIMORONI_PICOSYSTEM
+// non-default pins
+// TODO: clean this up?
 pimoroni::ST7789 st7789(240, 240, (uint16_t *)screen_fb, 5, 9, 6, 7, 12, 8, 4);
 #else
-pimoroni::ST7789 st7789(240, 240, (uint16_t *)screen_fb);
+pimoroni::ST7789 st7789(ST7789_WIDTH, ST7789_HEIGHT, (uint16_t *)screen_fb);
 #endif
 static bool have_vsync = false;
 #endif
@@ -334,7 +338,7 @@ int main() {
       if(cur_screen_mode == ScreenMode::lores) {
         buf_index ^= 1;
 
-        screen.data = screen_fb + (buf_index) * (120 * 120 * 2);
+        screen.data = screen_fb + (buf_index) * lores_page_size;
         st7789.frame_buffer = (uint16_t *)screen.data;
       }
 

--- a/32blit-pico/storage.cpp
+++ b/32blit-pico/storage.cpp
@@ -5,6 +5,7 @@
 
 #include "hardware/flash.h"
 #include "hardware/sync.h"
+#include "pico/binary_info.h"
 
 static const uint32_t storage_size = PICO_FLASH_SIZE_BYTES / 4;
 static const uint32_t storage_offset = PICO_FLASH_SIZE_BYTES - storage_size;
@@ -12,6 +13,15 @@ static const uint32_t storage_offset = PICO_FLASH_SIZE_BYTES - storage_size;
 void get_storage_size(uint16_t &block_size, uint32_t &num_blocks) {
   block_size = FLASH_SECTOR_SIZE;
   num_blocks = storage_size / FLASH_SECTOR_SIZE;
+
+  bi_decl(bi_block_device(
+    BINARY_INFO_MAKE_TAG('3', 'B'),
+    "32Blit",
+    XIP_BASE + storage_offset,
+    storage_size,
+    nullptr,
+    BINARY_INFO_BLOCK_DEV_FLAG_READ | BINARY_INFO_BLOCK_DEV_FLAG_WRITE | BINARY_INFO_BLOCK_DEV_FLAG_PT_NONE
+  ))
 }
 
 int32_t storage_read(uint32_t sector, uint32_t offset, void *buffer, uint32_t size_bytes) {

--- a/docs/pico.md
+++ b/docs/pico.md
@@ -61,7 +61,7 @@ Building a boilerplate project is similar, but first you need to import the Pico
 cmake_minimum_required(VERSION 3.9)
 
 # this is a wrapper for the pico sdk import files, which are only included if PICO_BOARD is set
-include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake)
+include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake OPTIONAL)
 
 project(my-amazing-gane)
 ...


### PR DESCRIPTION
Just some minor stuff. binary info stuff results in:
```
picotool info -a ./hardware-test.uf2 
File ./hardware-test.uf2:

Program Information
 name:            Hardware Test
 version:         v1.0.0
 web site:        https://github.com/32blit/32blit-sdk
 description:     A test of 32Blit's inputs and outputs.
 features:        UART stdin / stdout
 binary start:    0x10000000
 binary end:      0x10019914
 embedded drive:  0x10c00000-0x11000000 (4096K): 32Blit

Fixed Pin Information
 0:   UART0 TX
 1:   UART0 RX
 13:  Green LED
 14:  Red LED
 15:  Blue LED
 16:  Y Button
 17:  X Button
 18:  A Button
 19:  B Button
 20:  DOWN Button
 21:  RIGHT Button
 22:  LEFT Button
 23:  UP Button

Build Information
 sdk version:       1.2.0
 pico_board:        pimoroni_picosystem
 build date:        Aug 22 2021
 build attributes:  RelWithDebInfo
```
(no display pins yet as they're not constants, I should probably refactor the driver a bit now that it isn't a copy/paste from pimoroni-pico)