### PR TITLE
Intersect menu clip rect with the old one

### DIFF
--- a/32blit/engine/menu.hpp
+++ b/32blit/engine/menu.hpp
@@ -54,7 +54,7 @@ protected:
       }
 
       auto old_clip = screen.clip;
-      screen.clip = Rect(x, y, w, display_height);
+      screen.clip = screen.clip.intersection({x, y, w, display_height});
       y += (int)scroll_offset + margin_y;
 
       // items


### PR DESCRIPTION
So I thought I could make a menu slide in by setting its y coord to outside the screen... and got a very nasty crash as `blit::Menu` would end up setting a clip rect that extended past the bottom of the screen.

Fix this by intersecting with the previous rect instead of replacing it, which would also allow you to clip the menu if you wanted as well.