### PR TITLE
Fix CDC FIFO used getting out of sync

### DIFF
--- a/32blit-stm32/Inc/CDCCommandStream.h
+++ b/32blit-stm32/Inc/CDCCommandStream.h
@@ -26,7 +26,7 @@ struct CDCFifoElement
 class CDCCommandStream
 {
 public:
-	CDCCommandStream() : m_uFifoReadPos(0), m_uFifoWritePos(0), m_uFifoUsedCount(0)
+	CDCCommandStream() : m_uFifoReadPos(0), m_uFifoWritePos(0)
 	{
 		Init();
 	}
@@ -44,11 +44,6 @@ public:
 	void						ReleaseFifoWriteBuffer(uint8_t uLen);
 	CDCFifoElement  *GetFifoReadElement(void);
 	void 						ReleaseFifoReadElement(void);
-	bool						IsFifoFull(void)
-	{
-		return m_uFifoUsedCount==CDC_FIFO_BUFFERS;
-	}
-
 
 private:
 	typedef enum { stDetect, stDetectCommandWord, stDispatch, stProcessing, stError } StreamState;
@@ -74,7 +69,6 @@ private:
 	CDCFifoElement m_fifoElements[CDC_FIFO_BUFFERS];
 	uint8_t				 m_uFifoReadPos;
 	uint8_t				 m_uFifoWritePos;
-	uint8_t				 m_uFifoUsedCount;
 
 	bool					m_bNeedsUSBResume;
 

--- a/32blit-stm32/Src/CDCCommandStream.cpp
+++ b/32blit-stm32/Src/CDCCommandStream.cpp
@@ -212,7 +212,7 @@ uint32_t CDCCommandStream::GetTimeTaken(void)
 uint8_t	*CDCCommandStream::GetFifoWriteBuffer(void)
 {
 	uint8_t *pData = NULL;
-	if(m_uFifoUsedCount < CDC_FIFO_BUFFERS - 1)
+	if((m_uFifoWritePos + 1) % CDC_FIFO_BUFFERS != m_uFifoReadPos)
 	{
 		pData = m_fifoElements[m_uFifoWritePos].m_data;
 	}
@@ -228,13 +228,12 @@ void	CDCCommandStream::ReleaseFifoWriteBuffer(uint8_t uLen)
 	m_uFifoWritePos++;
 	if(m_uFifoWritePos == CDC_FIFO_BUFFERS)
 		m_uFifoWritePos = 0;
-	m_uFifoUsedCount++;
 }
 
 CDCFifoElement  *CDCCommandStream::GetFifoReadElement(void)
 {
 	CDCFifoElement *pElement = NULL;
-	if(m_uFifoUsedCount)
+	if(m_uFifoReadPos != m_uFifoWritePos)
 		pElement = &m_fifoElements[m_uFifoReadPos];
 	return pElement;
 }
@@ -244,7 +243,6 @@ void CDCCommandStream::ReleaseFifoReadElement(void)
 	m_uFifoReadPos++;
 	if(m_uFifoReadPos == CDC_FIFO_BUFFERS)
 		m_uFifoReadPos = 0;
-	m_uFifoUsedCount--;
 }
 
 // usb host glue


### PR DESCRIPTION
... by deleting it.

I found a .blit that would reliably fail to flash (99% bug). Adding any
extra logging to the USB code caused it to work, as did writing extra
data at the end. Then I noticed that the read index was sometimes behind
the write index by several entries, but "used" was 0.

I think this is what was happening:

- FIFO write is called from the USB interupt
- write increments "used", read decrements it
- those inc/decs are actually "load, add, store"
- interrupt can happen in the middle of that
- write increments from interrupt in the middle of the decrement in read
- "used" is now too low

So, I deleted the used variable and checked the read/write index instead
... and that .blit now works reliably.


This hopefully fixes the "99% bug"... I've tested this with my usual "flash everything" script (86 .blits this time).