### PR TITLE
Allow building for pico by specifying a toolchain, same as 32blit

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CMAKE_C_STANDARD 11)
 
 # Initialise the Pico SDK
+include (pico_sdk_import.cmake)
+include (pico_extras_import.cmake)
 pico_sdk_init()
 
 set(32BLIT_PICO 1 PARENT_SCOPE)

--- a/pico.toolchain
+++ b/pico.toolchain
@@ -1,0 +1,106 @@
+# todo there is probably a more "cmake" way of doing this going thru the standard path with our "PICO" platform
+#  i.e. CMake<Lang>Information and whatnot
+
+# Toolchain file is processed multiple times, however, it cannot access CMake cache on some runs.
+# We store the search path in an environment variable so that we can always access it.
+if (NOT "${PICO_TOOLCHAIN_PATH}" STREQUAL "")
+    set(ENV{PICO_TOOLCHAIN_PATH} "${PICO_TOOLCHAIN_PATH}")
+endif ()
+
+# Find the compiler executable and store its path in a cache entry ${compiler_path}.
+# If not found, issue a fatal message and stop processing. PICO_TOOLCHAIN_PATH can be provided from
+# commandline as additional search path.
+function(pico_find_compiler compiler_path compiler_exe)
+    # Search user provided path first.
+    find_program(
+            ${compiler_path} ${compiler_exe}
+            PATHS ENV PICO_TOOLCHAIN_PATH
+            PATH_SUFFIXES bin
+            NO_DEFAULT_PATH
+    )
+
+    # If not then search system paths.
+    if ("${${compiler_path}}" STREQUAL "${compiler_path}-NOTFOUND")
+        if (DEFINED ENV{PICO_TOOLCHAIN_PATH})
+            message(WARNING "PICO_TOOLCHAIN_PATH specified ($ENV{PICO_TOOLCHAIN_PATH}), but ${compiler_exe} not found there")
+        endif()
+        find_program(${compiler_path} ${compiler_exe})
+    endif ()
+    if ("${${compiler_path}}" STREQUAL "${compiler_path}-NOTFOUND")
+        set(PICO_TOOLCHAIN_PATH "" CACHE PATH "Path to search for compiler.")
+        message(FATAL_ERROR "Compiler '${compiler_exe}' not found, you can specify search path with\
+            \"PICO_TOOLCHAIN_PATH\".")
+    endif ()
+endfunction()
+
+
+# include our Platform/PICO.cmake
+set(CMAKE_SYSTEM_NAME PICO)
+set(CMAKE_SYSTEM_PROCESSOR cortex-m0plus)
+
+if (NOT PICO_GCC_TRIPLE)
+    if (DEFINED ENV{PICO_GCC_TRIPLE})
+        set(PICO_GCC_TRIPLE $ENV{PICO_GCC_TRIPLE})
+        message("PICO_GCC_TRIPLE set from environment: $ENV{PICO_GCC_TRIPLE}")
+    else()
+        set(PICO_GCC_TRIPLE arm-none-eabi)
+        #pico_message_debug("PICO_GCC_TRIPLE defaulted to arm-none-eabi")
+    endif()
+endif()
+
+# Find GCC for ARM.
+pico_find_compiler(PICO_COMPILER_CC ${PICO_GCC_TRIPLE}-gcc)
+pico_find_compiler(PICO_COMPILER_CXX ${PICO_GCC_TRIPLE}-g++)
+set(PICO_COMPILER_ASM "${PICO_COMPILER_CC}" CACHE INTERNAL "")
+pico_find_compiler(PICO_OBJCOPY ${PICO_GCC_TRIPLE}-objcopy)
+pico_find_compiler(PICO_OBJDUMP ${PICO_GCC_TRIPLE}-objdump)
+
+# Specify the cross compiler.
+set(CMAKE_C_COMPILER ${PICO_COMPILER_CC} CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER ${PICO_COMPILER_CXX} CACHE FILEPATH "C++ compiler")
+set(CMAKE_C_OUTPUT_EXTENSION .o)
+
+# todo should we be including CMakeASMInformation anyway - i guess that is host side
+set(CMAKE_ASM_COMPILER ${PICO_COMPILER_ASM} CACHE FILEPATH "ASM compiler")
+set(CMAKE_ASM_COMPILE_OBJECT "<CMAKE_ASM_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT>   -c <SOURCE>")
+set(CMAKE_INCLUDE_FLAG_ASM "-I")
+set(CMAKE_OBJCOPY ${PICO_OBJCOPY} CACHE FILEPATH "")
+set(CMAKE_OBJDUMP ${PICO_OBJDUMP} CACHE FILEPATH "")
+
+# Disable compiler checks.
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+# Add target system root to cmake find path.
+get_filename_component(PICO_COMPILER_DIR "${PICO_COMPILER_CC}" DIRECTORY)
+get_filename_component(CMAKE_FIND_ROOT_PATH "${PICO_COMPILER_DIR}" DIRECTORY)
+
+# Look for includes and libraries only in the target system prefix.
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+#set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 0)
+
+# todo move to platform/Generix-xxx
+
+# on ARM -mcpu should not be mixed with -march
+set(ARM_GCC_COMMON_FLAGS " -mcpu=cortex-m0plus -mthumb")
+foreach(LANG IN ITEMS C CXX ASM)
+    set(CMAKE_${LANG}_FLAGS_INIT "${ARM_GCC_COMMON_FLAGS}")
+    if (PICO_DEOPTIMIZED_DEBUG)
+        set(CMAKE_${LANG}_FLAGS_DEBUG_INIT "-O0")
+    else()
+        set(CMAKE_${LANG}_FLAGS_DEBUG_INIT "-Og")
+    endif()
+    set(CMAKE_${LANG}_LINK_FLAGS "-Wl,--build-id=none")
+endforeach()
+
+if (NOT PICO_BOARD)
+    set(PICO_BOARD pimoroni_picosystem)
+endif()
+
+if (NOT PICO_SDK_PATH)
+    set(PICO_SDK_PATH ${CMAKE_CURRENT_LIST_DIR}/../pico-sdk)
+endif()


### PR DESCRIPTION
To build a project for pico just do:

    cmake -DCMAKE_TOOLCHAIN_FILE=../../32blit-sdk/pico.toolchain ..

You may optionally override PICO_BOARD and PICO_SDK_PATH