### PR TITLE
Implement forced 16 bit screenmodes

### DIFF
--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -64,6 +64,7 @@ static volatile bool do_render = true;
 static Surface &set_screen_mode(ScreenMode mode) {
   switch(mode) {
     case ScreenMode::lores:
+    case ScreenMode::lores_565:
       screen = lores_screen;
       // window
 #ifdef DISPLAY_ST7789
@@ -75,6 +76,7 @@ static Surface &set_screen_mode(ScreenMode mode) {
       break;
 
     case ScreenMode::hires:
+    case ScreenMode::hires_565:
 #if defined(DISPLAY_ST7789) && ALLOW_HIRES
       if(have_vsync)
         do_render = true;

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include "SDL.h"
 
+#include "32blit.hpp"
 #include "Renderer.hpp"
 #include "System.hpp"
 
@@ -63,20 +64,46 @@ void Renderer::resize(int width, int height) {
 	if (fb_hires_texture) {
 		SDL_DestroyTexture(fb_hires_texture);
 	}
+    if (fb_lores_565_texture) {
+        SDL_DestroyTexture(fb_lores_texture);
+    }
+    if (fb_hires_565_texture) {
+        SDL_DestroyTexture(fb_hires_texture);
+    }
 
-	fb_lores_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
-	fb_hires_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
+    fb_lores_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
+    fb_hires_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
+    fb_lores_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
+    fb_hires_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
 }
 
 void Renderer::update(System *sys) {
-	if (sys->mode() == 0) {
-		current = fb_lores_texture;
-	} else {
-		current = fb_hires_texture;
-	}
+    bool lores = false;
+    switch(sys->mode()) {
+        case blit::ScreenMode::lores:
+            current = fb_lores_texture;
+            lores = true;
+            break;
+        case blit::ScreenMode::hires:
+            current = fb_hires_texture;
+            break;
+        case blit::ScreenMode::hires_palette:
+            current = fb_hires_texture;
+            break;
+        case blit::ScreenMode::lores_565:
+            current = fb_lores_565_texture;
+            lores = true;
+            break;
+        case blit::ScreenMode::hires_565:
+            current = fb_hires_565_texture;
+            break;
+        default:
+            current = fb_hires_texture;
+            break;
+    }
 
-  if(is_lores != (sys->mode() == 0)) {
-    is_lores = sys->mode() == 0;
+  if(is_lores != lores) {
+    is_lores = lores;
     set_mode(mode);
   }
 

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -25,5 +25,7 @@ class Renderer {
 
 		SDL_Texture *fb_lores_texture = nullptr;
 		SDL_Texture *fb_hires_texture = nullptr;
+        SDL_Texture *fb_lores_565_texture = nullptr;
+        SDL_Texture *fb_hires_565_texture = nullptr;
 		SDL_Texture *current = nullptr;
 };

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -7,7 +7,7 @@
 
 namespace blit {
 
-  enum   ScreenMode  { lores, hires, hires_palette };
+  enum   ScreenMode  { lores, hires, hires_palette, lores_565, hires_565 };
   extern Surface      &screen;
 
 


### PR DESCRIPTION
You can set ScreenMode::lores_565 or ScreenMode::hires_565 to be
guaranteed a 16 bit framebuffer on every platform. On Pico, this
does exactly the same as the normal screenmodes.