### PR TITLE
Pico ST7789 refactoring

### DIFF
--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -345,8 +345,10 @@ int main() {
 
       ::render(now);
 
-      if(!have_vsync)
+      if(!have_vsync) {
+        while(st7789.dma_is_busy()) {} // may need to wait for lores.
         st7789.update();
+      }
 
       if(last_render && !backlight_enabled) {
         // the first render should have made it to the screen at this point

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -34,6 +34,7 @@ uint8_t screen_fb[ST7789_WIDTH * ST7789_HEIGHT * 2];
 #else
 uint8_t screen_fb[lores_page_size * 2]; // double-buffered
 #endif
+static bool have_vsync = false;
 
 static Surface lores_screen(screen_fb, PixelFormat::RGB565, Size(ST7789_WIDTH / 2, ST7789_HEIGHT / 2));
 static Surface hires_screen(screen_fb, PixelFormat::RGB565, Size(ST7789_WIDTH, ST7789_HEIGHT));
@@ -45,16 +46,6 @@ static Surface lores_screen(screen_fb, PixelFormat::RGB565, Size(160, 120));
 
 static blit::AudioChannel channels[CHANNEL_COUNT];
 
-#ifdef DISPLAY_ST7789
-#ifdef PIMORONI_PICOSYSTEM
-// non-default pins
-// TODO: clean this up?
-pimoroni::ST7789 st7789(240, 240, (uint16_t *)screen_fb, 5, 9, 6, 7, 12, 8, 4);
-#else
-pimoroni::ST7789 st7789(ST7789_WIDTH, ST7789_HEIGHT, (uint16_t *)screen_fb);
-#endif
-static bool have_vsync = false;
-#endif
 
 ScreenMode cur_screen_mode = ScreenMode::lores;
 // double buffering for lores
@@ -71,7 +62,7 @@ static Surface &set_screen_mode(ScreenMode mode) {
       if(have_vsync)
         do_render = true; // prevent starting an update during switch
 
-      st7789.set_pixel_double(true);
+      st7789::set_pixel_double(true);
 #endif
       break;
 
@@ -81,8 +72,8 @@ static Surface &set_screen_mode(ScreenMode mode) {
         do_render = true;
 
       screen = hires_screen;
-      st7789.frame_buffer = (uint16_t *)screen_fb;
-      st7789.set_pixel_double(false);
+      st7789::frame_buffer = (uint16_t *)screen_fb;
+      st7789::set_pixel_double(false);
 #else
       return screen;
 #endif
@@ -182,8 +173,8 @@ void update(uint32_t);
 
 #ifdef DISPLAY_ST7789
 void vsync_callback(uint gpio, uint32_t events) {
-  if(!do_render && !st7789.dma_is_busy()) {
-    st7789.update();
+  if(!do_render && !st7789::dma_is_busy()) {
+    st7789::update();
     do_render = true;
   }
 }
@@ -302,10 +293,11 @@ int main() {
 
 #ifdef DISPLAY_ST7789
   bool backlight_enabled = false;
-  st7789.init();
-  st7789.clear();
+  st7789::frame_buffer = (uint16_t *)screen_fb;
+  st7789::init();
+  st7789::clear();
 
-  have_vsync = st7789.vsync_callback(vsync_callback);
+  have_vsync = st7789::vsync_callback(vsync_callback);
 #endif
 
 #ifdef DISPLAY_SCANVIDEO
@@ -335,24 +327,24 @@ int main() {
     auto now = ::now();
 
 #ifdef DISPLAY_ST7789
-    if((do_render || (!have_vsync && now - last_render >= 20)) && (cur_screen_mode == ScreenMode::lores || !st7789.dma_is_busy())) {
+    if((do_render || (!have_vsync && now - last_render >= 20)) && (cur_screen_mode == ScreenMode::lores || !st7789::dma_is_busy())) {
       if(cur_screen_mode == ScreenMode::lores) {
         buf_index ^= 1;
 
         screen.data = screen_fb + (buf_index) * lores_page_size;
-        st7789.frame_buffer = (uint16_t *)screen.data;
+        st7789::frame_buffer = (uint16_t *)screen.data;
       }
 
       ::render(now);
 
       if(!have_vsync) {
-        while(st7789.dma_is_busy()) {} // may need to wait for lores.
-        st7789.update();
+        while(st7789::dma_is_busy()) {} // may need to wait for lores.
+        st7789::update();
       }
 
       if(last_render && !backlight_enabled) {
         // the first render should have made it to the screen at this point
-        st7789.set_backlight(255);
+        st7789::set_backlight(255);
         backlight_enabled = true;
       }
 

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -26,7 +26,8 @@
 using namespace blit;
 
 #ifdef DISPLAY_ST7789
-static const int lores_page_size = (ST7789_WIDTH / 2) * (ST7789_HEIGHT / 2) * 2;
+// height rounded up to handle the 135px display
+static const int lores_page_size = (ST7789_WIDTH / 2) * ((ST7789_HEIGHT + 1) / 2) * 2;
 
 #if ALLOW_HIRES
 uint8_t screen_fb[ST7789_WIDTH * ST7789_HEIGHT * 2];

--- a/32blit-pico/st7789.cpp
+++ b/32blit-pico/st7789.cpp
@@ -80,7 +80,7 @@ namespace pimoroni {
       if(++cur_scanline > st7789_ptr->win_h / 2)
         return;
 
-      auto count = cur_scanline == st7789_ptr->win_h / 2 ? st7789_ptr->win_w / 4  : st7789_ptr->win_w / 2;
+      auto count = cur_scanline == (st7789_ptr->win_h + 1) / 2 ? st7789_ptr->win_w / 4  : st7789_ptr->win_w / 2;
 
       dma_channel_set_trans_count(channel, count, false);
       dma_channel_set_read_addr(channel, st7789_ptr->upd_frame_buffer + (cur_scanline - 1) * (st7789_ptr->win_w / 2), true);

--- a/32blit-pico/st7789.cpp
+++ b/32blit-pico/st7789.cpp
@@ -170,6 +170,21 @@ namespace pimoroni {
         command(reg::STE, 2, "\x01\x2C");
       }
 
+      if(width == 320 && height == 240) {
+        command(reg::PORCTRL, 5, "\x0c\x0c\x00\x33\x33");
+        command(reg::GCTRL, 1, "\x74");
+        command(reg::VCOMS, 1, "\x2f");
+        command(reg::LCMCTRL, 1, "\2c");
+        command(reg::LCMCTRL, 1, "\x22");
+        command(reg::VDVVRHEN, 1, "\x01");
+        command(reg::VRHS, 1, "\x19");
+        command(reg::VDVS, 1, "\x20");
+        command(reg::PWCTRL1, 2, "\xa4\xa1");
+        command(0xd6, 1, "\xa1"); // ???
+        command(reg::PVGAMCTRL, 14, "\xF0\x08\x0F\x0B\x0B\x07\x34\x43\x4B\x38\x14\x13\x2C\x31");
+        command(reg::NVGAMCTRL, 14, "\xF0\x0C\x11\x09\x08\x24\x34\x33\x4A\x3A\x16\x16\x2E\x32");
+      }
+
       command(reg::FRCTRL2, 1, "\x15"); // 50Hz
 
       command(reg::INVON);   // set inversion mode
@@ -189,6 +204,9 @@ namespace pimoroni {
         madctl |= MADCTL::COL_ORDER | MADCTL::SWAP_XY | MADCTL::SCAN_ORDER;
         set_window(40, 53, 240, 135);
       }
+
+      if(width == 320 && height == 240)
+        set_window(0, 0, 320, 240);
 
       command(reg::MADCTL,    1, (char *)&madctl);
     }

--- a/32blit-pico/st7789.cpp
+++ b/32blit-pico/st7789.cpp
@@ -6,6 +6,7 @@
 #include "hardware/dma.h"
 #include "hardware/irq.h"
 #include "hardware/pwm.h"
+#include "pico/binary_info.h"
 #include "pico/time.h"
 
 #include "config.h"
@@ -131,12 +132,17 @@ namespace st7789 {
     gpio_set_function(CS, GPIO_FUNC_SIO);
     gpio_set_dir(CS, GPIO_OUT);
 
+    bi_decl_if_func_used(bi_1pin_with_name(DC, "Display D/C"));
+    bi_decl_if_func_used(bi_1pin_with_name(CS, "Display CS"));
+
     // if supported by the display then the vsync pin is
     // toggled high during vertical blanking period
 #ifdef VSYNC
     gpio_set_function(VSYNC, GPIO_FUNC_SIO);
     gpio_set_dir(VSYNC, GPIO_IN);
     gpio_set_pulls(VSYNC, false, true);
+
+    bi_decl_if_func_used(bi_1pin_with_name(VSYNC, "Display TE/VSync"));
 #endif
 
     // if a backlight pin is provided then set it up for
@@ -147,6 +153,7 @@ namespace st7789 {
     pwm_init(pwm_gpio_to_slice_num(BACKLIGHT), &pwm_cfg, true);
     gpio_set_function(BACKLIGHT, GPIO_FUNC_PWM);
 
+    bi_decl_if_func_used(bi_1pin_with_name(BACKLIGHT, "Display Backlight"));
 #endif
 
 #ifdef RESET
@@ -155,6 +162,8 @@ namespace st7789 {
     gpio_put(RESET, 0);
     sleep_ms(100);
     gpio_put(RESET, 1);
+
+    bi_decl_if_func_used(bi_1pin_with_name(RESET, "Display Reset"));
 #endif
 
     // setup PIO
@@ -177,6 +186,9 @@ namespace st7789 {
 
     pio_sm_init(pio, pio_sm, pio_offset, &cfg);
     pio_sm_set_enabled(pio, pio_sm, true);
+
+    bi_decl_if_func_used(bi_1pin_with_name(MOSI, "Display TX"));
+    bi_decl_if_func_used(bi_1pin_with_name(SCK, "Display SCK"));
 
     // if auto_init_sequence then send initialisation sequence
     // for our standard displays based on the width and height

--- a/32blit-pico/st7789.cpp
+++ b/32blit-pico/st7789.cpp
@@ -69,21 +69,19 @@ namespace st7789 {
   static uint16_t win_w, win_h; // window size
 
 #ifdef PIMORONI_PICOSYSTEM
-  static const int8_t cs     = PICOSYSTEM_LCD_CSN_PIN;
-  static const int8_t dc     = PICOSYSTEM_LCD_DC_PIN;
-  static const int8_t sck    = PICOSYSTEM_LCD_SCLK_PIN;
-  static const int8_t mosi   = PICOSYSTEM_LCD_MOSI_PIN;
-  static const int8_t bl     = PICOSYSTEM_BACKLIGHT_PIN;
-  static const int8_t vsync  = PICOSYSTEM_LCD_VSYNC_PIN;
-  static const int8_t reset  = PICOSYSTEM_LCD_RESET_PIN;
+  #define CS        PICOSYSTEM_LCD_CSN_PIN
+  #define DC        PICOSYSTEM_LCD_DC_PIN
+  #define SCK       PICOSYSTEM_LCD_SCLK_PIN
+  #define MOSI      PICOSYSTEM_LCD_MOSI_PIN
+  #define BACKLIGHT PICOSYSTEM_BACKLIGHT_PIN
+  #define VSYNC     PICOSYSTEM_LCD_VSYNC_PIN
+  #define RESET     PICOSYSTEM_LCD_RESET_PIN
 #else
-  static const int8_t cs     = PICO_DEFAULT_SPI_CSN_PIN;
-  static const int8_t dc     = 16;
-  static const int8_t sck    = PICO_DEFAULT_SPI_SCK_PIN;
-  static const int8_t mosi   = PICO_DEFAULT_SPI_TX_PIN;
-  static const int8_t bl     = 20;
-  static const int8_t vsync  = -1; // only available on some products
-  static const int8_t reset  = -1;
+  #define CS        PICO_DEFAULT_SPI_CSN_PIN
+  #define DC        16
+  #define SCK       PICO_DEFAULT_SPI_SCK_PIN
+  #define MOSI      PICO_DEFAULT_SPI_TX_PIN
+  #define BACKLIGHT 20
 #endif
 
   static bool write_mode = false; // in RAMWR
@@ -127,36 +125,37 @@ namespace st7789 {
 
   void init(bool auto_init_sequence) {
     // configure pins
-    gpio_set_function(dc, GPIO_FUNC_SIO);
-    gpio_set_dir(dc, GPIO_OUT);
+    gpio_set_function(DC, GPIO_FUNC_SIO);
+    gpio_set_dir(DC, GPIO_OUT);
 
-    gpio_set_function(cs, GPIO_FUNC_SIO);
-    gpio_set_dir(cs, GPIO_OUT);
+    gpio_set_function(CS, GPIO_FUNC_SIO);
+    gpio_set_dir(CS, GPIO_OUT);
 
     // if supported by the display then the vsync pin is
     // toggled high during vertical blanking period
-    if(vsync != -1) {
-      gpio_set_function(vsync, GPIO_FUNC_SIO);
-      gpio_set_dir(vsync, GPIO_IN);
-      gpio_set_pulls(vsync, false, true);
-    }
+#ifdef VSYNC
+    gpio_set_function(VSYNC, GPIO_FUNC_SIO);
+    gpio_set_dir(VSYNC, GPIO_IN);
+    gpio_set_pulls(VSYNC, false, true);
+#endif
 
     // if a backlight pin is provided then set it up for
     // pwm control
-    if(bl != -1) {
-      pwm_config cfg = pwm_get_default_config();
-      pwm_set_wrap(pwm_gpio_to_slice_num(bl), 65535);
-      pwm_init(pwm_gpio_to_slice_num(bl), &cfg, true);
-      gpio_set_function(bl, GPIO_FUNC_PWM);
-    }
+#ifdef BACKLIGHT
+    pwm_config pwm_cfg = pwm_get_default_config();
+    pwm_set_wrap(pwm_gpio_to_slice_num(BACKLIGHT), 65535);
+    pwm_init(pwm_gpio_to_slice_num(BACKLIGHT), &pwm_cfg, true);
+    gpio_set_function(BACKLIGHT, GPIO_FUNC_PWM);
 
-    if(reset != -1) {
-      gpio_set_function(reset, GPIO_FUNC_SIO);
-      gpio_set_dir(reset, GPIO_OUT);
-      gpio_put(reset, 0);
-      sleep_ms(100);
-      gpio_put(reset, 1);
-    }
+#endif
+
+#ifdef RESET
+    gpio_set_function(RESET, GPIO_FUNC_SIO);
+    gpio_set_dir(RESET, GPIO_OUT);
+    gpio_put(RESET, 0);
+    sleep_ms(100);
+    gpio_put(RESET, 1);
+#endif
 
     // setup PIO
     pio_offset = pio_add_program(pio, &st7789_raw_program);
@@ -167,14 +166,14 @@ namespace st7789 {
     sm_config_set_clkdiv(&cfg, 2); // back to 62.5MHz from overclock
 #endif
     sm_config_set_out_shift(&cfg, false, true, 8);
-    sm_config_set_out_pins(&cfg, mosi, 1);
+    sm_config_set_out_pins(&cfg, MOSI, 1);
     sm_config_set_fifo_join(&cfg, PIO_FIFO_JOIN_TX);
-    sm_config_set_sideset_pins(&cfg, sck);
+    sm_config_set_sideset_pins(&cfg, SCK);
 
-    pio_gpio_init(pio, mosi);
-    pio_gpio_init(pio, sck);
-    pio_sm_set_consecutive_pindirs(pio, pio_sm, mosi, 1, true);
-    pio_sm_set_consecutive_pindirs(pio, pio_sm, sck, 1, true);
+    pio_gpio_init(pio, MOSI);
+    pio_gpio_init(pio, SCK);
+    pio_sm_set_consecutive_pindirs(pio, pio_sm, MOSI, 1, true);
+    pio_sm_set_consecutive_pindirs(pio, pio_sm, SCK, 1, true);
 
     pio_sm_init(pio, pio_sm, pio_offset, &cfg);
     pio_sm_set_enabled(pio, pio_sm, true);
@@ -279,21 +278,21 @@ namespace st7789 {
       write_mode = false;
     }
 
-    gpio_put(cs, 0);
+    gpio_put(CS, 0);
 
-    gpio_put(dc, 0); // command mode
+    gpio_put(DC, 0); // command mode
     pio_put_byte(pio, pio_sm, command);
 
     if(data) {
       pio_wait(pio, pio_sm);
-      gpio_put(dc, 1); // data mode
+      gpio_put(DC, 1); // data mode
 
       for(size_t i = 0; i < len; i++)
         pio_put_byte(pio, pio_sm, data[i]);
     }
 
     pio_wait(pio, pio_sm);
-    gpio_put(cs, 1);
+    gpio_put(CS, 1);
   }
 
   void update(bool dont_block) {
@@ -317,19 +316,22 @@ namespace st7789 {
   }
 
   void set_backlight(uint8_t brightness) {
+#ifdef BACKLIGHT
     // gamma correct the provided 0-255 brightness value onto a
     // 0-65535 range for the pwm counter
     float gamma = 2.8;
     uint16_t value = (uint16_t)(pow((float)(brightness) / 255.0f, gamma) * 65535.0f + 0.5f);
-    pwm_set_gpio_level(bl, value);
+    pwm_set_gpio_level(BACKLIGHT, value);
+#endif
   }
 
   bool vsync_callback(gpio_irq_callback_t callback) {
-    if(vsync == -1)
-      return false;
-
-    gpio_set_irq_enabled_with_callback(vsync, GPIO_IRQ_EDGE_RISE, true, callback);
+#ifdef VSYNC
+    gpio_set_irq_enabled_with_callback(VSYNC, GPIO_IRQ_EDGE_RISE, true, callback);
     return true;
+#else
+    return false;
+#endif
   }
 
   void set_window(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
@@ -377,13 +379,13 @@ namespace st7789 {
 
     // setup for writing
     uint8_t r = reg::RAMWR;
-    gpio_put(cs, 0);
+    gpio_put(CS, 0);
 
-    gpio_put(dc, 0); // command mode
+    gpio_put(DC, 0); // command mode
     pio_put_byte(pio, pio_sm, r);
     pio_wait(pio, pio_sm);
 
-    gpio_put(dc, 1); // data mode
+    gpio_put(DC, 1); // data mode
 
     pio_sm_set_enabled(pio, pio_sm, false);
     pio_sm_restart(pio, pio_sm);

--- a/32blit-pico/st7789.hpp
+++ b/32blit-pico/st7789.hpp
@@ -3,66 +3,21 @@
 #include "hardware/pio.h"
 #include "hardware/gpio.h"
 
-namespace pimoroni {
+namespace st7789 {
 
-  class ST7789 {
-    PIO pio = pio0;
-    uint pio_sm = 0;
-    uint pio_offset = 0, pio_double_offset = 0;
+  extern uint16_t *frame_buffer;
 
-    uint32_t dma_channel;
+  void init(bool auto_init_sequence = true);
 
-    // screen properties
-    uint16_t width;
-    uint16_t height;
-    uint16_t row_stride;
+  void command(uint8_t command, size_t len = 0, const char *data = NULL);
+  bool vsync_callback(gpio_irq_callback_t callback);
+  void update(bool dont_block = false);
+  void set_backlight(uint8_t brightness);
 
-    uint16_t win_w, win_h; // window size
+  void set_window(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  void set_pixel_double(bool pd);
 
-    // interface pins with our standard defaults where appropriate
-    int8_t cs     = 17;
-    int8_t dc     = 16;
-    int8_t sck    = 18;
-    int8_t mosi   = 19;
-    int8_t bl     = 20;
-    int8_t vsync  = -1; // only available on some products
-    int8_t reset  = -1;
+  void clear();
 
-    bool write_mode = false; // in RAMWR
-    bool pixel_double = false;
-    uint16_t *upd_frame_buffer = nullptr;
-
-  public:
-    // frame buffer where pixel data is stored
-    uint16_t *frame_buffer;
-
-  public:
-    ST7789(uint16_t width, uint16_t height, uint16_t *frame_buffer) :
-      width(width), height(height), win_w(width), win_h(height), frame_buffer(frame_buffer) {}
-
-    ST7789(uint16_t width, uint16_t height, uint16_t *frame_buffer,
-           uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t bl, uint8_t vsync, uint8_t reset) :
-      width(width), height(height), win_w(width), win_h(height),
-      cs(cs), dc(dc), sck(sck), mosi(mosi), bl(bl), vsync(vsync), reset(reset), frame_buffer(frame_buffer) {}
-
-    void init(bool auto_init_sequence = true);
-
-    void command(uint8_t command, size_t len = 0, const char *data = NULL);
-    bool vsync_callback(gpio_irq_callback_t callback);
-    void update(bool dont_block = false);
-    void set_backlight(uint8_t brightness);
-
-    void set_window(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
-    void set_pixel_double(bool pd);
-
-    void clear();
-
-    bool dma_is_busy();
-
-  private:
-    void prepare_write();
-
-    friend void st7789_dma_irq_handler();
-  };
-
+  bool dma_is_busy();
 }


### PR DESCRIPTION
Some of this is for supporting the other displays, but the rest results in more constants, more metadata and less hardcoded pins. (And also fixes it being a class that can only have one instance because reasons)