### PR TITLE
Fix GCC 10

### DIFF
--- a/32blit-stm32/STM32H750VBTx.ld
+++ b/32blit-stm32/STM32H750VBTx.ld
@@ -235,7 +235,7 @@ SECTIONS
   /* Remove information from the standard libraries */
   /DISCARD/ :
   {
-    libc.a ( * )
+    libc_nano.a ( * )
     libm.a ( * )
     libgcc.a ( * )
   }


### PR DESCRIPTION
Well, that was easy. There's still some bits in the docs that specify GCC 9, but that's still what's being tested by the actions so I left it.

I've tested this with the official 10.3-2021.07 and 10-2020-q4-major toolchains and it fixes the linker errors there.

(I was expecting this to be some big incompatibility/obscure corner case with the PIC libs... but nope, it's a five character fix...)