### PR TITLE
No more 32BLIT_DIR for STM32 builds

### DIFF
--- a/docs/32blit.md
+++ b/docs/32blit.md
@@ -102,7 +102,7 @@ You can build a project based on the boilerplate (https://github.com/32blit/32bl
 ```
 mkdir build.stm32
 cd build.stm32
-cmake .. -D32BLIT_DIR="/path/to/32blit/repo" -DCMAKE_TOOLCHAIN_FILE=/path/to/32blit/repo/32blit.toolchain
+cmake .. -DCMAKE_TOOLCHAIN_FILE=/path/to/32blit/repo/32blit.toolchain
 make
 ```
 


### PR DESCRIPTION
The toolchain sets 32BLIT_DIR and everywhere else in the docs was only setting the toolchain.