### PR TITLE
Set 32BLIT_DIR in the Pico toolchain too

### DIFF
--- a/pico.toolchain
+++ b/pico.toolchain
@@ -104,3 +104,5 @@ endif()
 if (NOT PICO_SDK_PATH)
     set(PICO_SDK_PATH ${CMAKE_CURRENT_LIST_DIR}/../pico-sdk)
 endif()
+
+set(32BLIT_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "Path to 32blit.cmake")


### PR DESCRIPTION
For consistency with 32blit.toolchain. More importantly, this makes the command in the boilerplate/docs actually work.