### PR TITLE
Screen mode cleanup and extended API

### DIFF
--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -39,12 +39,12 @@ uint8_t screen_fb[lores_page_size * 2]; // double-buffered
 #endif
 static bool have_vsync = false;
 
-static Surface lores_screen(screen_fb, PixelFormat::RGB565, Size(ST7789_WIDTH / 2, ST7789_HEIGHT / 2));
-static Surface hires_screen(screen_fb, PixelFormat::RGB565, Size(ST7789_WIDTH, ST7789_HEIGHT));
-//static Surface hires_palette_screen(screen_fb, PixelFormat::P, Size(320, 240));
+static const blit::SurfaceTemplate lores_screen{screen_fb, Size(ST7789_WIDTH / 2, ST7789_HEIGHT / 2), blit::PixelFormat::RGB565, nullptr};
+static const blit::SurfaceTemplate hires_screen{screen_fb, Size(ST7789_WIDTH, ST7789_HEIGHT), blit::PixelFormat::RGB565, nullptr};
+
 #elif defined(DISPLAY_SCANVIDEO)
 uint8_t screen_fb[160 * 120 * 4];
-static Surface lores_screen(screen_fb, PixelFormat::RGB565, Size(160, 120));
+static const blit::SurfaceTemplate lores_screen{screen_fb, Size(160, 120), blit::PixelFormat::RGB565, nullptr};
 #endif
 
 static blit::AudioChannel channels[CHANNEL_COUNT];

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -26,6 +26,8 @@
 
 using namespace blit;
 
+static SurfaceInfo cur_surf_info;
+
 #ifdef DISPLAY_ST7789
 // height rounded up to handle the 135px display
 static const int lores_page_size = (ST7789_WIDTH / 2) * ((ST7789_HEIGHT + 1) / 2) * 2;
@@ -54,10 +56,10 @@ static volatile int buf_index = 0;
 
 static volatile bool do_render = true;
 
-static Surface &set_screen_mode(ScreenMode mode) {
+static SurfaceInfo &set_screen_mode(ScreenMode mode) {
   switch(mode) {
     case ScreenMode::lores:
-      screen = lores_screen;
+      cur_surf_info = lores_screen;
       // window
 #ifdef DISPLAY_ST7789
       if(have_vsync)
@@ -72,11 +74,11 @@ static Surface &set_screen_mode(ScreenMode mode) {
       if(have_vsync)
         do_render = true;
 
-      screen = hires_screen;
+      cur_surf_info = hires_screen;
       st7789::frame_buffer = (uint16_t *)screen_fb;
       st7789::set_pixel_double(false);
 #else
-      return screen;
+      return cur_surf_info;
 #endif
       break;
 
@@ -87,7 +89,7 @@ static Surface &set_screen_mode(ScreenMode mode) {
 
   cur_screen_mode = mode;
 
-  return blit::screen;
+  return cur_surf_info;
 }
 
 static uint32_t now() {

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -92,6 +92,10 @@ static SurfaceInfo &set_screen_mode(ScreenMode mode) {
   return cur_surf_info;
 }
 
+static void set_screen_palette(const Pen *colours, int num_cols) {
+
+}
+
 static uint32_t now() {
   return to_ms_since_boot(get_absolute_time());
 }
@@ -247,7 +251,7 @@ int main() {
   api.channels = ::channels;
 
   api.set_screen_mode = ::set_screen_mode;
-  // api.set_screen_palette = ::set_screen_palette;
+  api.set_screen_palette = ::set_screen_palette;
   api.now = ::now;
   api.random = ::random;
   // api.exit = ::exit;

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include "SDL.h"
 
+#include "graphics/surface.hpp"
+
 #include "Renderer.hpp"
 #include "System.hpp"
 
@@ -28,11 +30,15 @@ Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width)
 
   fb_lores_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
 	fb_hires_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
+  fb_lores_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
+  fb_hires_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
 }
 
 Renderer::~Renderer() {
 	SDL_DestroyTexture(fb_lores_texture);
 	SDL_DestroyTexture(fb_hires_texture);
+	SDL_DestroyTexture(fb_lores_565_texture);
+	SDL_DestroyTexture(fb_hires_565_texture);
 	SDL_DestroyRenderer(renderer);
 }
 
@@ -62,10 +68,12 @@ void Renderer::resize(int width, int height) {
 }
 
 void Renderer::update(System *sys) {
+  auto format = blit::PixelFormat(sys->format());
+
 	if (sys->mode() == 0) {
-		current = fb_lores_texture;
+		current = format == blit::PixelFormat::RGB565 ? fb_lores_565_texture : fb_lores_texture;
 	} else {
-		current = fb_hires_texture;
+		current = format == blit::PixelFormat::RGB565 ? fb_hires_565_texture : fb_hires_texture;
 	}
 
   if(is_lores != (sys->mode() == 0)) {

--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -25,6 +25,9 @@ Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width)
 	SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
 	SDL_RenderClear(renderer);
 	SDL_RenderPresent(renderer);
+
+  fb_lores_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
+	fb_hires_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
 }
 
 Renderer::~Renderer() {
@@ -56,16 +59,6 @@ void Renderer::resize(int width, int height) {
 
   if (mode == Stretch)
 	  set_mode(mode);
-
-	if (fb_lores_texture) {
-		SDL_DestroyTexture(fb_lores_texture);
-	}
-	if (fb_hires_texture) {
-		SDL_DestroyTexture(fb_hires_texture);
-	}
-
-	fb_lores_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
-	fb_hires_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
 }
 
 void Renderer::update(System *sys) {

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -25,5 +25,7 @@ class Renderer {
 
 		SDL_Texture *fb_lores_texture = nullptr;
 		SDL_Texture *fb_hires_texture = nullptr;
+		SDL_Texture *fb_lores_565_texture = nullptr;
+		SDL_Texture *fb_hires_565_texture = nullptr;
 		SDL_Texture *current = nullptr;
 };

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -67,6 +67,7 @@ static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTempl
 
   switch(new_surf_template.format) {
     case blit::PixelFormat::RGB:
+    case blit::PixelFormat::RGB565:
       break;
     case blit::PixelFormat::P:
       new_surf_template.palette = palette;
@@ -308,6 +309,10 @@ void System::loop()
 
 Uint32 System::mode() {
 	return _mode;
+}
+
+Uint32 System::format() {
+	return Uint32(cur_format);
 }
 
 void System::update_texture(SDL_Texture *texture) {

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -52,6 +52,36 @@ static void set_screen_palette(const blit::Pen *colours, int num_cols) {
 	memcpy(palette, colours, num_cols * sizeof(blit::Pen));
 }
 
+static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {
+  new_surf_template.data = framebuffer;
+
+  switch(new_mode) {
+    case blit::ScreenMode::lores:
+      new_surf_template.bounds = __fb_lores.bounds;
+      break;
+    case blit::ScreenMode::hires:
+    case blit::ScreenMode::hires_palette:
+      new_surf_template.bounds = __fb_hires.bounds;
+      break;
+  }
+
+  switch(new_surf_template.format) {
+    case blit::PixelFormat::RGB:
+      break;
+    case blit::PixelFormat::P:
+      new_surf_template.palette = palette;
+      break;
+
+    default:
+      return false;
+  }
+
+  _mode = new_mode;
+  cur_format = new_surf_template.format;
+
+  return true;
+}
+
 // blit timer callback
 std::chrono::steady_clock::time_point start;
 uint32_t now() {
@@ -170,6 +200,7 @@ void System::run() {
 	blit::api.debug = ::blit_debug;
 	blit::api.set_screen_mode = ::set_screen_mode;
 	blit::api.set_screen_palette = ::set_screen_palette;
+  blit::api.set_screen_mode_format = ::set_screen_mode_format;
 	blit::update = ::update;
 	blit::render = ::render;
 

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -13,12 +13,12 @@
 #include "engine/api_private.hpp"
 
 // blit framebuffer memory
-uint8_t framebuffer[320 * 240 * 3];
-blit::Surface __fb_hires((uint8_t *)framebuffer, blit::PixelFormat::RGB, blit::Size(320, 240));
-blit::Surface __fb_hires_pal((uint8_t *)framebuffer, blit::PixelFormat::P, blit::Size(320, 240));
-blit::Surface __fb_lores((uint8_t *)framebuffer, blit::PixelFormat::RGB, blit::Size(160, 120));
-
+static uint8_t framebuffer[320 * 240 * 3];
 static blit::Pen palette[256];
+
+static const blit::SurfaceTemplate __fb_hires{framebuffer, blit::Size(320, 240), blit::PixelFormat::RGB, nullptr};
+static const blit::SurfaceTemplate __fb_hires_pal{framebuffer, blit::Size(320, 240), blit::PixelFormat::P, palette};
+static const blit::SurfaceTemplate __fb_lores{framebuffer, blit::Size(160, 120), blit::PixelFormat::RGB, nullptr};
 
 // blit debug callback
 void blit_debug(const char *message) {
@@ -147,8 +147,6 @@ System::System() {
 	s_loop_update = SDL_CreateSemaphore(0);
 	s_loop_redraw = SDL_CreateSemaphore(0);
 	s_loop_ended = SDL_CreateSemaphore(0);
-
-	__fb_hires_pal.palette = palette;
 }
 
 System::~System() {

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -236,7 +236,7 @@ void System::run() {
 
   blit::api.get_metadata = ::get_metadata;
 
-	::set_screen_mode(blit::lores);
+	blit::set_screen_mode(blit::lores);
 
 #ifdef __EMSCRIPTEN__
 	::init();

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -27,21 +27,22 @@ void blit_debug(const char *message) {
 
 // blit screenmode callback
 blit::ScreenMode _mode = blit::ScreenMode::lores;
-blit::Surface &set_screen_mode(blit::ScreenMode new_mode) {
+blit::SurfaceInfo cur_surf_info;
+blit::SurfaceInfo &set_screen_mode(blit::ScreenMode new_mode) {
 	_mode = new_mode;
-    switch(_mode) {
-      case blit::ScreenMode::lores:
-        blit::screen = __fb_lores;
-        break;
-      case blit::ScreenMode::hires:
-        blit::screen = __fb_hires;
-        break;
-      case blit::ScreenMode::hires_palette:
-        blit::screen = __fb_hires_pal;
-        break;
-    }
+  switch(_mode) {
+    case blit::ScreenMode::lores:
+      cur_surf_info = __fb_lores;
+      break;
+    case blit::ScreenMode::hires:
+      cur_surf_info = __fb_hires;
+      break;
+    case blit::ScreenMode::hires_palette:
+      cur_surf_info = __fb_hires_pal;
+      break;
+  }
 
-	return blit::screen;
+	return cur_surf_info;
 }
 
 static void set_screen_palette(const blit::Pen *colours, int num_cols) {

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -18,6 +18,8 @@ class System {
 		void loop();
 
 		Uint32 mode();
+    Uint32 format();
+
 		void update_texture(SDL_Texture *);
 		void notify_redraw();
 

--- a/32blit-stm32/Inc/display.hpp
+++ b/32blit-stm32/Inc/display.hpp
@@ -13,24 +13,28 @@ extern "C" {
 
 using namespace blit;
 
+namespace blit {
+  struct SurfaceInfo;
+}
+
 namespace display {
 
   extern ScreenMode mode;
   extern bool needs_render;
 
-  void init();  
+  void init();
 
-  void enable_vblank_interrupt(); 
+  void enable_vblank_interrupt();
 
-  Surface &set_screen_mode(ScreenMode new_mode);
+  SurfaceInfo &set_screen_mode(ScreenMode new_mode);
   void set_screen_palette(const Pen *colours, int num_cols);
   void flip(const Surface &source);
 
   void screen_init();
   void ltdc_init();
-	
+
   uint32_t get_dma2d_count(void);
-  
+
   void dma2d_lores_flip_Step2(void);
   void dma2d_lores_flip_Step3(void);
   void dma2d_lores_flip_Step4(void);

--- a/32blit-stm32/Inc/display.hpp
+++ b/32blit-stm32/Inc/display.hpp
@@ -14,6 +14,7 @@ extern "C" {
 using namespace blit;
 
 namespace blit {
+  struct SurfaceTemplate;
   struct SurfaceInfo;
 }
 
@@ -28,6 +29,8 @@ namespace display {
 
   SurfaceInfo &set_screen_mode(ScreenMode new_mode);
   void set_screen_palette(const Pen *colours, int num_cols);
+  bool set_screen_mode_format(ScreenMode new_mode, SurfaceTemplate &new_surf_template);
+
   void flip(const Surface &source);
 
   void screen_init();

--- a/32blit-stm32/Inc/display.hpp
+++ b/32blit-stm32/Inc/display.hpp
@@ -38,9 +38,9 @@ namespace display {
 
   uint32_t get_dma2d_count(void);
 
-  void dma2d_lores_flip_Step2(void);
-  void dma2d_lores_flip_Step3(void);
-  void dma2d_lores_flip_Step4(void);
+  void dma2d_lores_flip_step2(void);
+  void dma2d_lores_flip_step3(void);
+  void dma2d_lores_flip_step4(void);
 }
 
 

--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -377,10 +377,14 @@ void blit_init() {
 
     blit::api.set_screen_mode = display::set_screen_mode;
     blit::api.set_screen_palette = display::set_screen_palette;
+    blit::api.set_screen_mode_format = display::set_screen_mode_format;
+
     display::set_screen_mode(blit::lores);
+
     blit::update = ::update;
     blit::render = ::render;
     blit::init   = ::init;
+
     blit::api.open_file = ::open_file;
     blit::api.read_file = ::read_file;
     blit::api.write_file = ::write_file;

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -148,6 +148,7 @@ namespace display {
 
     switch(new_surf_template.format) {
       case PixelFormat::RGB:
+      case PixelFormat::RGB565:
         break;
       case PixelFormat::P:
         new_surf_template.palette = palette;
@@ -173,7 +174,10 @@ namespace display {
     // set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M_PFC);
     // set source pixel format (clear bits 3..0 of foreground format register)
-    MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB888);
+    if(format == PixelFormat::RGB565)
+      MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB565);
+    else
+      MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB888);
     // set source buffer address
     DMA2D->FGMAR = (uintptr_t)source.data;
     // set target pixel format (clear bits 3..0 of output format register)
@@ -250,7 +254,13 @@ namespace display {
     // set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M_PFC);
     // set source pixel format (clear bits 3..0 of foreground format register)
-    MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, format == PixelFormat::P ? LL_DMA2D_INPUT_MODE_L8 : LL_DMA2D_INPUT_MODE_RGB888);
+    if(format == PixelFormat::RGB565)
+      MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB565);
+    else if(format == PixelFormat::P)
+      MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_L8);
+    else
+      MODIFY_REG(DMA2D->FGPFCCR, DMA2D_FGPFCCR_CM, LL_DMA2D_INPUT_MODE_RGB888);
+
     // set source buffer address
     DMA2D->FGMAR = (uintptr_t)source.data;
     // set target pixel format (clear bits 3..0 of output format register)

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -3,6 +3,7 @@
 
 #include "spi-st7272a.h"
 #include "32blit.hpp"
+#include "engine/api_private.hpp"
 
 #include "display.hpp"
 #include "stm32h7xx_ll_dma2d.h"
@@ -61,6 +62,8 @@ namespace display {
   Surface __fb_hires_pal((uint8_t *)&__fb_start, PixelFormat::P, Size(320, 240));
   Surface __fb_lores((uint8_t *)&__fb_start, PixelFormat::RGB, Size(160, 120));
 
+  static SurfaceInfo cur_surf_info; // used to pass screen info back through API
+
   Pen palette[256];
 
   ScreenMode mode = ScreenMode::lores;
@@ -103,21 +106,21 @@ namespace display {
     display::needs_render = false;
   }
 
-  Surface &set_screen_mode(ScreenMode new_mode) {
+  SurfaceInfo &set_screen_mode(ScreenMode new_mode) {
     requested_mode = new_mode;
     switch(new_mode) {
       case ScreenMode::lores:
-        screen = __fb_lores;
+        cur_surf_info = blit::screen = __fb_lores;
         break;
       case ScreenMode::hires:
-        screen = __fb_hires;
+        cur_surf_info = blit::screen = __fb_hires;
         break;
       case ScreenMode::hires_palette:
-        screen = __fb_hires_pal;
+        cur_surf_info = blit::screen = __fb_hires_pal;
         break;
     }
 
-    return screen;
+    return cur_surf_info;
   }
 
   void set_screen_palette(const Pen *colours, int num_cols) {

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -34,13 +34,13 @@ void DMA2D_IRQHandler(void){
 	switch(count){
 		case 3:
 			display::needs_render = true;
-			display::dma2d_lores_flip_Step2();
+			display::dma2d_lores_flip_step2();
 			break;
 		case 2:
-			display::dma2d_lores_flip_Step3();
+			display::dma2d_lores_flip_step3();
 			break;
 		case 1:
-			display::dma2d_lores_flip_Step4();
+			display::dma2d_lores_flip_step4();
 			break;
 		case 0:   //highres, pal mode goto case 0 directly
 			CLEAR_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);//disable the DMA2D interrupt
@@ -55,7 +55,7 @@ void DMA2D_IRQHandler(void){
 namespace display {
 	void update_ltdc_for_mode();
 
-  __IO uint32_t dma2d_stepCount = 0;
+  __IO uint32_t dma2d_step_count = 0;
 
   static Pen palette[256];
   // lo and hi res screen back buffers
@@ -189,7 +189,7 @@ namespace display {
 		//enable the DMA2D interrupt
 	  SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);
 		//set DMA2d steps //set occupied
-    dma2d_stepCount = 0;
+    dma2d_step_count = 0;
     // trigger start of dma2d transfer
     DMA2D->CR |= DMA2D_CR_START;
   }
@@ -217,7 +217,7 @@ namespace display {
     //enable the DMA2D interrupt
 	  SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);
 		//set DMA2d steps //set occupied
-    dma2d_stepCount = 0;
+    dma2d_step_count = 0;
     // trigger start of dma2d transfer
     DMA2D->CR |= DMA2D_CR_START;
     // update pal next, dma2d could work at same time
@@ -265,12 +265,12 @@ namespace display {
     DMA2D->OOR = 1;
 	  SET_BIT(DMA2D->CR, DMA2D_CR_TCIE|DMA2D_CR_TEIE|DMA2D_CR_CEIE);//enable the DMA2D interrupt
 		//set DMA2d steps //set occupied
-    dma2d_stepCount = 3;
+    dma2d_step_count = 3;
     // trigger start of dma2d transfer
     DMA2D->CR |= DMA2D_CR_START;
   }
 
-	void dma2d_lores_flip_Step2(void){
+	void dma2d_lores_flip_step2(void){
 		//Step 2.
 			// set the transform type (clear bits 17..16 of control register)
 		MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
@@ -289,11 +289,11 @@ namespace display {
 			// set the output offset
 		DMA2D->OOR = 1;
 				// trigger start of dma2d transfer
-		dma2d_stepCount = 2;
+		dma2d_step_count = 2;
 		DMA2D->CR |= DMA2D_CR_START;
 	}
 
-	void dma2d_lores_flip_Step3(void){
+	void dma2d_lores_flip_step3(void){
 		//step 3.
 		// set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
@@ -311,13 +311,12 @@ namespace display {
     DMA2D->FGOR = 0;
     // set the output offset
     DMA2D->OOR = 160;
-		dma2d_stepCount = 1;
+		dma2d_step_count = 1;
 			// trigger start of dma2d transfer
 		DMA2D->CR |= DMA2D_CR_START;
-
 	}
 
-	void dma2d_lores_flip_Step4(void){
+	void dma2d_lores_flip_step4(void){
 		// set the transform type (clear bits 17..16 of control register)
     MODIFY_REG(DMA2D->CR, DMA2D_CR_MODE, LL_DMA2D_MODE_M2M);
     // set source pixel format (clear bits 3..0 of foreground format register)
@@ -334,7 +333,7 @@ namespace display {
     DMA2D->FGOR = 160;
     // set the output offset
     DMA2D->OOR = 160;
-		dma2d_stepCount = 0;
+		dma2d_step_count = 0;
 		// trigger start of dma2d transfer
 		DMA2D->CR |= DMA2D_CR_START;
 	}
@@ -430,6 +429,6 @@ namespace display {
   }
 
 	uint32_t get_dma2d_count(void){
-		return dma2d_stepCount;
+		return dma2d_step_count;
 	}
 }

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -19,6 +19,26 @@ namespace blit {
 
   constexpr uint16_t api_version_major = 0, api_version_minor = 0;
 
+  struct SurfaceInfo {
+    SurfaceInfo() = default;
+    SurfaceInfo(const Surface &surf): data(surf.data), bounds(surf.bounds), format(surf.format), palette(surf.palette) {}
+
+    uint8_t *data = nullptr;
+    Size bounds;
+
+    // unused, here for compat reasons
+    Rect clip;
+    uint8_t alpha;
+    Pen pen;
+
+    PixelFormat format;
+    uint8_t pixel_stride; // unused
+    uint16_t row_stride; // unused
+
+    Surface *mask = nullptr; // unused
+    Pen *palette = nullptr;
+  };
+
   #pragma pack(push, 4)
   struct API {
     uint16_t version_major;
@@ -34,7 +54,7 @@ namespace blit {
 
     AudioChannel *channels;
 
-    Surface &(*set_screen_mode)  (ScreenMode new_mode);
+    SurfaceInfo &(*set_screen_mode)  (ScreenMode new_mode);
     void (*set_screen_palette)  (const Pen *colours, int num_cols);
     uint32_t (*now)();
     uint32_t (*random)();

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -19,9 +19,19 @@ namespace blit {
 
   constexpr uint16_t api_version_major = 0, api_version_minor = 0;
 
+  // template for screen modes
+  struct SurfaceTemplate {
+    uint8_t *data = nullptr;
+    Size bounds;
+    PixelFormat format;
+    Pen *palette = nullptr;
+  };
+
+  // subset of Surface for API compat
   struct SurfaceInfo {
     SurfaceInfo() = default;
     SurfaceInfo(const Surface &surf): data(surf.data), bounds(surf.bounds), format(surf.format), palette(surf.palette) {}
+    SurfaceInfo(const SurfaceTemplate &surf): data(surf.data), bounds(surf.bounds), format(surf.format), palette(surf.palette) {}
 
     uint8_t *data = nullptr;
     Size bounds;

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -17,7 +17,7 @@ namespace blit {
 
   using AllocateCallback = uint8_t *(*)(size_t);
 
-  constexpr uint16_t api_version_major = 0, api_version_minor = 0;
+  constexpr uint16_t api_version_major = 0, api_version_minor = 1;
 
   // template for screen modes
   struct SurfaceTemplate {
@@ -116,6 +116,8 @@ namespace blit {
     GameMetadata (*get_metadata)();
 
     bool tick_function_changed;
+
+    bool (*set_screen_mode_format)(ScreenMode new_mode, SurfaceTemplate &new_surf_template);
   };
   #pragma pack(pop)
 

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -19,6 +19,19 @@ namespace blit {
     screen.palette = new_screen.palette;
   }
 
+  bool set_screen_mode(ScreenMode new_mode, PixelFormat format) {
+    SurfaceTemplate new_screen;
+    new_screen.format = format;
+
+    if(!api.set_screen_mode_format(new_mode, new_screen))
+      return false;
+
+    screen = Surface(new_screen.data, new_screen.format, new_screen.bounds);
+    screen.palette = new_screen.palette;
+
+    return true;
+  }
+
   void set_screen_palette(const Pen *colours, int num_cols) {
     api.set_screen_palette(colours, num_cols);
   }

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -16,6 +16,7 @@ namespace blit {
   extern void     (*render)           (uint32_t time);
 
   void set_screen_mode(ScreenMode new_mode);
+  bool set_screen_mode(ScreenMode new_mode, PixelFormat format);
   void set_screen_palette(const Pen *colours, int num_cols);
 
   uint32_t now();


### PR DESCRIPTION
I thought about it too much and had to write it... cleanup based on an old patch, 565 bits loosely based on the other PR.

The main thing this adds is: `bool set_screen_mode(ScreenMode new_mode, PixelFormat format)`, which enables:
 - Paletted `lores` mode on non-pico (doesn't reconfigure LTDC like `hires`, just changes the input format to the doubling magic)
 - RGB565 modes on non-pico
 - Returns false instead of just ignoring you on non-supported modes/formats (so everything except 565 on pico)
 - The API function this uses could easily be extended to allow things like passing in a framebuffer pointer

This does increase the API minor version, so games built with this won't run on older firmware (but old games will be fine).

[Updated screen mode test](https://github.com/32blit/32blit-sdk/files/7534853/screen-mode.zip). Cycles through all six mode/format combinations. A/B for manual mode change.

(Adding extra formats to the STM32 HAL is reasonably easy if for some reason someone wanted ARGB4444... or 1555... or even 4bit paletted)