### PR TITLE
Improve feedback for trying to use storage mode with no SD card

### DIFF
--- a/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
+++ b/32blit-stm32/Src/SystemMenu/connectivity_menu.cpp
@@ -45,6 +45,8 @@ void ConnectivityMenu::render_item(const Item &item, int y, int index) const {
     const char *label;
     if (get_files_open())
       label = "Files Open";
+    else if(!blit_sd_detected())
+      label = "No SD Card";
     else if (g_usbManager.GetType() == USBManager::usbtMSC)
       label = g_usbManager.GetStateName() + 4; // trim the "MSC "
     else
@@ -68,7 +70,7 @@ void ConnectivityMenu::item_activated(const Item &item) {
     // switch back manually if not mounted
     if (g_usbManager.GetState() == USBManager::usbsMSCInititalising)
       g_usbManager.SetType(USBManager::usbtCDC);
-    else if (!get_files_open() && !multiplayer::enabled)
+    else if (!get_files_open() && blit_sd_detected() && !multiplayer::enabled)
       g_usbManager.SetType(USBManager::usbtMSC);
     break;
   }


### PR DESCRIPTION
Refuse to enter storage mode with "No SD Card" instead of getting stuck at "initialising".


(Seems unmounting on Ubuntu is broken again though)