### PR TITLE
Blit function consistency shuffle

### DIFF
--- a/32blit/graphics/sprite.cpp
+++ b/32blit/graphics/sprite.cpp
@@ -14,7 +14,7 @@ namespace blit {
 
   /**
    * Return the bounds of a sprite by index
-   * 
+   *
    * Takes an index offset to the sprite in the spritesheet
    * and returns a `rect` describing the location and size of the sprite in pixels.
    *
@@ -27,7 +27,7 @@ namespace blit {
 
  /**
    * Return the bounds of a sprite by index
-   * 
+   *
    * Takes a `point` describing the x/y offset of the sprite in terms of tiles/units
    * and returns a `rect` describing the location of the sprite in pixels.
    *
@@ -40,7 +40,7 @@ namespace blit {
 
  /**
    * Return the bounds of a sprite by index
-   * 
+   *
    * Takes a `rect` describing the x/y offset and size of the sprite in terms of tiles/units
    * and returns a `rect` describing the location and size of the sprite in pixels.
    *
@@ -53,32 +53,18 @@ namespace blit {
 
 
   // unscaled sprites
-  
+
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite Index of the sprite in the sheet
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] transform to apply
    */
   void Surface::sprite(uint16_t sprite, const Point &position, uint8_t transform) {
     if(sprites == nullptr) return;
-    blit_sprite(
-      sprites->sprite_bounds(sprite), 
-      position, 
-      transform);
-  }
-
-  /**
-   * Draws a sprite to the surface
-   * 
-   * \param[in] sprite `point` describing the x/y offset of the sprite in the spritesheet in tiles/units
-   * \param[in] position `point` at which to place the sprite in the target surface
-   * \param[in] transform to apply
-   */
-  void Surface::sprite(const Point &sprite, const Point &position, uint8_t transform) {
-    if(sprites == nullptr) return;
-    blit_sprite(
+    blit(
+      sprites,
       sprites->sprite_bounds(sprite),
       position,
       transform);
@@ -86,14 +72,31 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
+   * \param[in] sprite `point` describing the x/y offset of the sprite in the spritesheet in tiles/units
+   * \param[in] position `point` at which to place the sprite in the target surface
+   * \param[in] transform to apply
+   */
+  void Surface::sprite(const Point &sprite, const Point &position, uint8_t transform) {
+    if(sprites == nullptr) return;
+    blit(
+      sprites,
+      sprites->sprite_bounds(sprite),
+      position,
+      transform);
+  }
+
+  /**
+   * Draws a sprite to the surface
+   *
    * \param[in] sprite `rect` describing the x/y offset and size of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] transform to apply
    */
-  void Surface::sprite(const Rect &sprite, const Point &position, uint8_t transform) {       
-    if(sprites == nullptr) return; 
-    blit_sprite(
+  void Surface::sprite(const Rect &sprite, const Point &position, uint8_t transform) {
+    if(sprites == nullptr) return;
+    blit(
+      sprites,
       sprites->sprite_bounds(sprite),
       position,
       transform);
@@ -103,7 +106,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite Index of the sprite in the sheet
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform the sprite
@@ -115,7 +118,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite `point` describing the x/y offset of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform the sprite
@@ -127,7 +130,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite `rect` describing the x/y offset and size of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform the sprite
@@ -141,7 +144,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite Index of the sprite in the sheet
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform & scale the sprite
@@ -158,7 +161,8 @@ namespace blit {
       roundf(8.0f * scale.y)
     );
 
-    stretch_blit_sprite(
+    stretch_blit(
+      sprites,
       sprites->sprite_bounds(sprite),
       dest_rect,
       transform);
@@ -166,7 +170,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite `point` describing the x/y offset of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform & scale the sprite
@@ -183,7 +187,8 @@ namespace blit {
       roundf(8.0f * scale.y)
     );
 
-    stretch_blit_sprite(
+    stretch_blit(
+      sprites,
       sprites->sprite_bounds(sprite),
       dest_rect,
       transform);
@@ -191,7 +196,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite `rect` describing the x/y offset and size of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform  & scale the sprite
@@ -208,7 +213,8 @@ namespace blit {
       roundf(sprite.h * 8.0f * scale.y)
     );
 
-    stretch_blit_sprite(
+    stretch_blit(
+      sprites,
       sprites->sprite_bounds(sprite),
       dest_rect,
       transform);
@@ -216,7 +222,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite Index of the sprite in the sheet
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform & scale the sprite
@@ -229,7 +235,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite `point` describing the x/y offset of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform & scale the sprite
@@ -242,7 +248,7 @@ namespace blit {
 
   /**
    * Draws a sprite to the surface
-   * 
+   *
    * \param[in] sprite `rect` describing the x/y offset and size of the sprite in the spritesheet in tiles/units
    * \param[in] position `point` at which to place the sprite in the target surface
    * \param[in] origin `point` around which to transform  & scale the sprite
@@ -288,15 +294,15 @@ namespace blit {
       this->blit(&ss, sr, pos - origin);
 
     }
-    
+
   }*/
   /*
   void surface::sprite(spritesheet &ss, uint16_t index, point pos, size span, point origin, float scale) {
     if (scale != 1.0f) {
       rect sr = ss.sprite_bounds(index);
       sr.w = span.w * ss.sprite_size.w;
-      sr.h = span.h * ss.sprite_size.h;            
-    
+      sr.h = span.h * ss.sprite_size.h;
+
       rect dr = rect(
         pos - (origin * scale),
         size(sr.w * scale, sr.h * scale)
@@ -313,4 +319,4 @@ namespace blit {
     }
   }*/
 
-} 
+}

--- a/32blit/graphics/sprite.hpp
+++ b/32blit/graphics/sprite.hpp
@@ -4,26 +4,4 @@
 
 namespace blit {
   using SpriteSheet [[deprecated]] = Surface;
-
-  /** 
-   * All sprite mirroring and rotations (90/180/270) can be composed
-   * of simple horizontal/vertical flips and x/y coordinate swaps.
-   *
-   * The bits set represent the transforms required to achieve the
-   * end result. Operations are performed (if needed) in the following 
-   * order: horizontal flip -> vertical flip -> x/y swap
-   * 
-   * For example a 90 degree rotation needs a vertical flip
-   * followed by an x/y coordinate swap.
-  */
-  enum SpriteTransform {
-    NONE = 0b000,
-    HORIZONTAL = 0b001,
-    VERTICAL = 0b010,
-    XYSWAP = 0b100,
-    R90 = 0b101,
-    R180 = 0b011,
-    R270 = 0b110
-  };
-
-} 
+}

--- a/32blit/graphics/surface.cpp
+++ b/32blit/graphics/surface.cpp
@@ -311,7 +311,7 @@ namespace blit {
    * \param p
    * \param t
    */
-  void Surface::blit(Surface *src, const Rect &sprite, const Point &p, uint8_t t) {
+  void Surface::blit(Surface *src, const Rect &sprite, const Point &p, int t) {
     Rect dr = clip.intersection(Rect(p.x, p.y, sprite.w, sprite.h));  // clipped destination rect
 
     if (dr.empty())
@@ -366,7 +366,7 @@ namespace blit {
    * \param p
    * \param t
    */
-  void Surface::stretch_blit(Surface *src, const Rect &sprite, const Rect &r, uint8_t t) {
+  void Surface::stretch_blit(Surface *src, const Rect &sprite, const Rect &r, int t) {
     Rect dr = clip.intersection(r);  // clipped destination rect
 
     if (dr.empty())

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -185,9 +185,18 @@ namespace blit {
     /*void outline_circle(const point &c, int32_t r);
 
     */
-    void blit(Surface *src, Rect r, Point p, bool hflip = false);
-    void stretch_blit(Surface *src, Rect sr, Rect dr);
+    void blit(Surface *src, Rect src_r, Point dst_p);
+    void blit(Surface *src, const Rect &src_r, const Point &dst_p, uint8_t transforms);
+
+    void stretch_blit(Surface *src, const Rect &src_r, const Rect &dst_r);
+    void stretch_blit(Surface *src, const Rect &src_r, const Rect &dst_r, uint8_t transforms);
+
     void stretch_blit_vspan(Surface *src, Point uv, uint16_t sc, Point p, int16_t dc);
+
+    [[deprecated]]
+    void blit(Surface *src, Rect r, Point p, bool hflip) {
+      blit(src, r, p, (uint8_t)(hflip ? SpriteTransform::HORIZONTAL : 0));
+    }
 
     void custom_blend(Surface *src, Rect r, Point p, std::function<void(uint8_t *psrc, uint8_t *pdest, int16_t c)> f);
     void custom_modify(Rect r, std::function<void(uint8_t *p, int16_t c)> f);
@@ -205,8 +214,15 @@ namespace blit {
     Rect sprite_bounds(const Point &p);
     Rect sprite_bounds(const Rect &r);
 
-    void blit_sprite(const Rect &src, const Point &p, uint8_t t = 0);
-    void stretch_blit_sprite(const Rect&src, const Rect &r, uint8_t t = 0);
+    [[deprecated]]
+    void blit_sprite(const Rect &src, const Point &p, uint8_t t = 0) {
+      blit(sprites, src, p, t);
+    }
+
+    [[deprecated]]
+    void stretch_blit_sprite(const Rect &src, const Rect &r, uint8_t t = 0) {
+      stretch_blit(sprites, src, r, t);
+    }
 
     void sprite(const Rect &sprite, const Point &position, uint8_t transform = 0);
     void sprite(const Point &sprite, const Point &position, uint8_t transform = 0);

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -186,16 +186,16 @@ namespace blit {
 
     */
     void blit(Surface *src, Rect src_r, Point dst_p);
-    void blit(Surface *src, const Rect &src_r, const Point &dst_p, uint8_t transforms);
+    void blit(Surface *src, const Rect &src_r, const Point &dst_p, int transforms);
 
     void stretch_blit(Surface *src, const Rect &src_r, const Rect &dst_r);
-    void stretch_blit(Surface *src, const Rect &src_r, const Rect &dst_r, uint8_t transforms);
+    void stretch_blit(Surface *src, const Rect &src_r, const Rect &dst_r, int transforms);
 
     void stretch_blit_vspan(Surface *src, Point uv, uint16_t sc, Point p, int16_t dc);
 
     [[deprecated]]
     void blit(Surface *src, Rect r, Point p, bool hflip) {
-      blit(src, r, p, (uint8_t)(hflip ? SpriteTransform::HORIZONTAL : 0));
+      blit(src, r, p, hflip ? SpriteTransform::HORIZONTAL : 0);
     }
 
     void custom_blend(Surface *src, Rect r, Point p, std::function<void(uint8_t *psrc, uint8_t *pdest, int16_t c)> f);

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -19,7 +19,26 @@
 
 namespace blit {
 
-  struct sprite_p;
+  /**
+   * All sprite mirroring and rotations (90/180/270) can be composed
+   * of simple horizontal/vertical flips and x/y coordinate swaps.
+   *
+   * The bits set represent the transforms required to achieve the
+   * end result. Operations are performed (if needed) in the following
+   * order: horizontal flip -> vertical flip -> x/y swap
+   *
+   * For example a 90 degree rotation needs a vertical flip
+   * followed by an x/y coordinate swap.
+  */
+  enum SpriteTransform {
+    NONE = 0b000,
+    HORIZONTAL = 0b001,
+    VERTICAL = 0b010,
+    XYSWAP = 0b100,
+    R90 = 0b101,
+    R180 = 0b011,
+    R270 = 0b110
+  };
 
 #pragma pack(push, 1)
   struct packed_image {

--- a/examples/shmup/shmup.cpp
+++ b/examples/shmup/shmup.cpp
@@ -110,7 +110,7 @@ void draw_tilebased_sprite(Surface* ss, Point origin, const std::vector<uint8_t>
       if (ship_mask & (0b10000000 >> jj)) {
         uint8_t offset_x = (jj * 8);
         uint8_t src_x = o_x + offset_x;
-        screen.blit(ss, Rect(src_x, src_y, 8, 8), Point(origin.x + (j * 8), origin.y + offset_y), hflip);
+        screen.blit(ss, Rect(src_x, src_y, 8, 8), Point(origin.x + (j * 8), origin.y + offset_y), hflip ? SpriteTransform::HORIZONTAL : 0);
       }
     }
   }


### PR DESCRIPTION
This is hopefully just some cleanup of `Surface` methods. It replaces  `(stretch_)blit_sprite` with new `(stretch_)blit` overloads that take a surface/transform and removes the optional `hflip` param from `blit()` (the new overloads allow a full transform).

There are deprecated wrappers to avoid breaking old code, though only one of the three functions was used in one example... and there only seems to be one repo on GitHub that uses the sprite blit functions directly (DANG).
