### PR TITLE
Prepend target name to generated metadata.cpp

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -279,7 +279,7 @@ const char *metadata_category = \"\${METADATA_CATEGORY}\";"
 		METADATA_CONTENT ESCAPE_QUOTES
 	)
 
-	file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_metadata.cpp CONTENT "${METADATA_CONTENT}")
+	file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_metadata.cpp CONTENT "${METADATA_CONTENT}")
 
-	target_sources(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/_metadata.cpp)
+	target_sources(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_metadata.cpp)
 endfunction()


### PR DESCRIPTION
Avoids a CMake error when you have multiple targets with metadata in the same CMakeLists/subdir.