### PR TITLE
Fix load_tmx flags typo

### DIFF
--- a/32blit/graphics/tilemap.hpp
+++ b/32blit/graphics/tilemap.hpp
@@ -51,7 +51,7 @@ namespace blit {
 
     enum LoadFlags {
       copy_tiles = (1 << 0),
-      copy_transforms = (1 << 0)
+      copy_transforms = (1 << 1)
     };
 
     TileMap(uint8_t *tiles, uint8_t *transforms, Size bounds, Surface *sprites);


### PR DESCRIPTION
These were supposed to be different flags. Probably unnoticed as the default is both and I use neither in blit kart.