### PR TITLE
Adjust SDL loop timing a bit

### DIFF
--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -306,9 +306,13 @@ void System::loop() {
   blit::joystick.y = shadow_joystick[1];
   SDL_UnlockMutex(m_input);
 
-  // only render at 50Hz
+  // only render at 50Hz (main loop runs at 100Hz)
+  // however, the emscripten loop (usually) runs at the display refresh rate
   auto time_now = ::now();
-  if(time_now - last_render_time >= 20) {
+#ifndef __EMSCRIPTEN__
+  if(time_now - last_render_time >= 20)
+#endif
+  {
     blit::render(time_now);
     last_render_time = time_now;
   }

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -251,12 +251,12 @@ void System::run() {
 }
 
 int System::timer_thread() {
-	// Signal the system loop every 20 msec.
+	// Signal the system loop every 10 msec.
 	int dropped = 0;
 	SDL_Event event = {};
 	event.type = timer_event;
 
-	while (SDL_SemWaitTimeout(s_timer_stop, 20)) {
+	while (SDL_SemWaitTimeout(s_timer_stop, 10)) {
 		if (SDL_SemValue(s_loop_update)) {
 			dropped++;
 			if(dropped > 100) {
@@ -296,20 +296,27 @@ int System::update_thread() {
 	return 0;
 }
 
-void System::loop()
-{
-	SDL_LockMutex(m_input);
-	blit::buttons = shadow_buttons;
-	blit::tilt.x = shadow_tilt[0];
-	blit::tilt.y = shadow_tilt[1];
-	blit::tilt.z = shadow_tilt[2];
-	blit::joystick.x = shadow_joystick[0];
-	blit::joystick.y = shadow_joystick[1];
-	SDL_UnlockMutex(m_input);
-	blit::tick(::now());
+void System::loop() {
+  SDL_LockMutex(m_input);
+  blit::buttons = shadow_buttons;
+  blit::tilt.x = shadow_tilt[0];
+  blit::tilt.y = shadow_tilt[1];
+  blit::tilt.z = shadow_tilt[2];
+  blit::joystick.x = shadow_joystick[0];
+  blit::joystick.y = shadow_joystick[1];
+  SDL_UnlockMutex(m_input);
+
+  // only render at 50Hz
+  auto time_now = ::now();
+  if(time_now - last_render_time >= 20) {
+    blit::render(time_now);
+    last_render_time = time_now;
+  }
+
+  blit::tick(::now());
   blit_input->rumble_controllers(blit::vibration);
-  blit::render(::now());
-	blit_multiplayer->update();
+
+  blit_multiplayer->update();
 }
 
 Uint32 System::mode() {

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -41,6 +41,8 @@ class System {
 
 		bool running = false;
 
+		Uint32 last_render_time = 0;
+
 		// shadow input
 		Uint32 shadow_buttons = 0;
 		float shadow_joystick[2] = {0, 0};


### PR DESCRIPTION
This fixes the fact that SDL only called `tick` every 20ms, so you would always be running behind and get two updates. Also switches `render`/`tick` around as SDL was backwards compared to STM32/Pico.