### PR TITLE
pico: Fix default screen mode

### DIFF
--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -359,7 +359,7 @@ int main() {
   init_fs();
   init_usb();
 
-  ::set_screen_mode(ScreenMode::lores);
+  blit::set_screen_mode(ScreenMode::lores);
 
   blit::render = ::render;
   blit::update = ::update;


### PR DESCRIPTION
Someone needs to setup `blit::screen`... Unbreaks everything that uses the "default" mode, which includes a lot of the examples :facepalm: 


(Err, whoops)