### PR TITLE
pico: Don't sleep when we need to render

### DIFF
--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -414,7 +414,7 @@ int main() {
     update_led();
     update_usb();
 
-    if(ms_to_next_update > 1)
+    if(ms_to_next_update > 1 && !do_render)
       best_effort_wfe_or_timeout(make_timeout_time_ms(ms_to_next_update - 1));
   }
 


### PR DESCRIPTION
We could end up missing frames if `update` doesn't take much time.

Fixes an empty `update`/`render` sometimes missing frames in `hires` and improves `logo` modified to use `hires` mode to get a constant 25 FPS instead of sometimes falling to ~16 (it also has an empty `update`).