### PR TITLE
Update Windows setup docs for VS2022

### DIFF
--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -14,10 +14,10 @@ You'll need to install:
 
  - [Git for Windows](https://git-scm.com/download/win)
  - [Python](https://www.python.org/downloads/)
- - At least the [Visual Studio build tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) (For local builds, select "C++ build tools"). This includes a copy of CMake. A full Visual Studio install can also be used.
+ - At least the [Visual Studio build tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) (For local builds, select "Desktop development with C++"). This includes a copy of CMake. A full Visual Studio install can also be used.
  - The [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) (For 32blit device builds, use the 9-2020-q2-update version). Make sure to select the "Add path to environment variable" at the end of the setup.
 
-Now open "Developer Command Prompt for VS 2019" and install the 32blit tools:
+Now open "Developer Command Prompt for VS 2022" and install the 32blit tools:
 ```
 py -m pip install 32blit
 ```


### PR DESCRIPTION
Setting up a new Windows install... everything still seems to work here, except things have moved a bit.

Using the latest Arm tools mostly works as well, but the firmware fails to link...
```
[ 95%] Linking CXX executable firmware.elf
AR10B2~1.EXE: error: ´╗┐CMakeFiles/firmware.dir/firmware.cpp.obj: No such file or directory
NMAKE : fatal error U1077: 'C:\PROGRA~2\GNUARM~1\102021~1.10\bin\AR10B2~1.EXE' : return code '0x1'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.31.31103\bin\HostX86\x86\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.31.31103\bin\HostX86\x86\nmake.exe"' : return code '0x2'
Stop.
```