### PR TITLE
Fix exit(0) crashing

### DIFF
--- a/32blit-stm32/Src/32blit.cpp
+++ b/32blit-stm32/Src/32blit.cpp
@@ -106,8 +106,11 @@ void blit_debug(const char *message) {
 void blit_exit(bool is_error) {
   if(is_error)
     blit_reset_with_error(); // likely an abort
-  else
-    blit_switch_execution(0, false); // switch back to firmware
+  else {
+    persist.reset_target = prtFirmware;
+    SCB_CleanDCache();
+    NVIC_SystemReset();
+  }
 }
 
 void enable_us_timer()


### PR DESCRIPTION
`exit` is marked as not returning, bad things happen if it does. This worked fine until #661 made it so that `blit_exit` didn't reset when there wasn't an error.

This is the easiest fix of always resetting in `blit_exit`... which isn't as clean an exit as you get from using the menu. While typing this patch I thought of an alternative, which is slightly more magic: https://github.com/Daft-Freak/32blit-beta/commit/645a3a504e8c92328e9811363937cfbdc5ae7758