### PR TITLE
Fix DIR leak in blit::list_files

### DIFF
--- a/32blit-pico/file.cpp
+++ b/32blit-pico/file.cpp
@@ -167,14 +167,14 @@ uint32_t get_file_length(void *fh) {
 }
 
 void list_files(const std::string &path, std::function<void(blit::FileInfo &)> callback) {
-  auto dir = new DIR();
+  DIR dir;
 
-  if(f_opendir(dir, path.c_str()) != FR_OK)
+  if(f_opendir(&dir, path.c_str()) != FR_OK)
     return;
 
   FILINFO ent;
 
-  while(f_readdir(dir, &ent) == FR_OK && ent.fname[0]) {
+  while(f_readdir(&dir, &ent) == FR_OK && ent.fname[0]) {
     blit::FileInfo info;
 
     info.name = ent.fname;
@@ -187,7 +187,7 @@ void list_files(const std::string &path, std::function<void(blit::FileInfo &)> c
     callback(info);
   }
 
-  f_closedir(dir);
+  f_closedir(&dir);
 }
 
 bool file_exists(const std::string &path) {

--- a/32blit-stm32/Src/file.cpp
+++ b/32blit-stm32/Src/file.cpp
@@ -111,14 +111,14 @@ void list_files(const std::string &path, std::function<void(blit::FileInfo &)> c
   if(g_usbManager.GetType() == USBManager::usbtMSC)
     return;
 
-  auto dir = new DIR();
+  DIR dir;
 
-  if(f_opendir(dir, path.c_str()) != FR_OK)
+  if(f_opendir(&dir, path.c_str()) != FR_OK)
     return;
 
   FILINFO ent;
 
-  while(f_readdir(dir, &ent) == FR_OK && ent.fname[0]) {
+  while(f_readdir(&dir, &ent) == FR_OK && ent.fname[0]) {
     blit::FileInfo info;
 
     info.name = ent.fname;
@@ -131,7 +131,7 @@ void list_files(const std::string &path, std::function<void(blit::FileInfo &)> c
     callback(info);
   }
 
-  f_closedir(dir);
+  f_closedir(&dir);
 }
 
 bool file_exists(const std::string &path) {


### PR DESCRIPTION
`blit::list_files` has been leaking a whole 56 bytes... for the last two years... This fixes it by just putting the `DIR` object on the stack instead.

(I wasn't even doing blit stuff, just came to uh, "borrow" some of the fatfs glue)