### PR TITLE
Add optional support for filtering in list_files

### DIFF
--- a/32blit/engine/file.cpp
+++ b/32blit/engine/file.cpp
@@ -29,10 +29,11 @@ namespace blit {
    *
    * \return Vector of files/directories
    */
-  std::vector<FileInfo> list_files(const std::string &path) {
+  std::vector<FileInfo> list_files(const std::string &path, std::function<bool(const FileInfo &)> filter) {
     std::vector<FileInfo> ret;
-    api.list_files(path, [&ret](FileInfo &file){
-      ret.push_back(file);
+    api.list_files(path, [&ret, &filter](FileInfo &file){
+      if(!filter || filter(file))
+        ret.push_back(file);
     });
 
     for(auto &buf_file : buf_files) {

--- a/32blit/engine/file.hpp
+++ b/32blit/engine/file.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,7 @@ namespace blit {
 
   bool is_storage_available();
 
-  std::vector<FileInfo> list_files(const std::string &path);
+  std::vector<FileInfo> list_files(const std::string &path, std::function<bool(const FileInfo &)> filter = nullptr);
   bool file_exists(const std::string &path);
   bool directory_exists(const std::string &path);
 


### PR DESCRIPTION
Mostly to avoid DaftBoy running out of memory while listing the root of my SD card... but seems useful for the launcher too.
