### PR TITLE
pico: scanvideo improvements

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -42,6 +42,7 @@ if(${PICO_BOARD} STREQUAL "vgaboard")
     target_link_libraries(BlitHalPico INTERFACE pico_scanvideo_dpi pico_audio_i2s)
     target_compile_definitions(BlitHalPico INTERFACE
         PICO_SCANVIDEO_PLANE1_VARIABLE_FRAGMENT_DMA=1
+        PICO_SCANVIDEO_MAX_SCANLINE_BUFFER_WORDS=12
         AUDIO_I2S
         DISPLAY_SCANVIDEO
     )

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -26,7 +26,7 @@ target_sources(BlitHalPico INTERFACE
 
 pico_generate_pio_header(BlitHalPico ${CMAKE_CURRENT_LIST_DIR}/st7789.pio)
 
-target_link_libraries(BlitHalPico INTERFACE hardware_dma hardware_pio hardware_pwm hardware_spi pico_stdlib pico_unique_id tinyusb_device)
+target_link_libraries(BlitHalPico INTERFACE hardware_dma hardware_pio hardware_pwm hardware_spi pico_multicore pico_stdlib pico_unique_id tinyusb_device)
 target_include_directories(BlitHalPico INTERFACE
     ${CMAKE_CURRENT_LIST_DIR} # for tusb_config
     ${CMAKE_CURRENT_LIST_DIR}/../3rd-party/fatfs

--- a/32blit-pico/display.cpp
+++ b/32blit-pico/display.cpp
@@ -131,7 +131,11 @@ void init_display_core1() {
 #ifdef DISPLAY_SCANVIDEO
   // no mode switching yet
 #if ALLOW_HIRES
+#if DISPLAY_HEIGHT == 160 // extra middle mode
+  scanvideo_setup(&vga_mode_213x160_60);
+#else
   scanvideo_setup(&vga_mode_320x240_60);
+#endif
 #else
   scanvideo_setup(&vga_mode_160x120_60);
 #endif

--- a/32blit-pico/display.hpp
+++ b/32blit-pico/display.hpp
@@ -5,6 +5,10 @@
 
 void init_display();
 void update_display(uint32_t time);
+
+void init_display_core1();
+void update_display_core1();
+
 bool display_render_needed();
 
 blit::SurfaceInfo &set_screen_mode(blit::ScreenMode mode);

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -4,6 +4,7 @@
 #include "hardware/structs/rosc.h"
 #include "hardware/vreg.h"
 #include "pico/binary_info.h"
+#include "pico/multicore.h"
 #include "pico/stdlib.h"
 
 #include "audio.hpp"
@@ -102,6 +103,13 @@ void init();
 void render(uint32_t);
 void update(uint32_t);
 
+void core1_main() {
+  multicore_lockout_victim_init();
+
+  while(true) {
+  }
+}
+
 int main() {
 #if OVERCLOCK_250
   // Apply a modest overvolt, default is 1.10v.
@@ -171,6 +179,8 @@ int main() {
   init_input();
   init_fs();
   init_usb();
+
+  multicore_launch_core1(core1_main);
 
   blit::set_screen_mode(ScreenMode::lores);
 

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -109,7 +109,11 @@ void core1_main() {
   core1_started = true;
   multicore_lockout_victim_init();
 
+  init_display_core1();
+
   while(true) {
+    update_display_core1();
+    sleep_us(1);
   }
 }
 

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -187,7 +187,9 @@ int main() {
   init_fs();
   init_usb();
 
+#if defined(DISPLAY_SCANVIDEO)
   multicore_launch_core1(core1_main);
+#endif
 
   blit::set_screen_mode(ScreenMode::lores);
 

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -103,7 +103,10 @@ void init();
 void render(uint32_t);
 void update(uint32_t);
 
+bool core1_started = false;
+
 void core1_main() {
+  core1_started = true;
   multicore_lockout_victim_init();
 
   while(true) {

--- a/32blit-pico/storage.cpp
+++ b/32blit-pico/storage.cpp
@@ -11,6 +11,8 @@
 static const uint32_t storage_size = PICO_FLASH_SIZE_BYTES / 4;
 static const uint32_t storage_offset = PICO_FLASH_SIZE_BYTES - storage_size;
 
+extern bool core1_started;
+
 void get_storage_size(uint16_t &block_size, uint32_t &num_blocks) {
   block_size = FLASH_SECTOR_SIZE;
   num_blocks = storage_size / FLASH_SECTOR_SIZE;
@@ -34,14 +36,16 @@ int32_t storage_read(uint32_t sector, uint32_t offset, void *buffer, uint32_t si
 int32_t storage_write(uint32_t sector, uint32_t offset, const uint8_t *buffer, uint32_t size_bytes) {
   auto status = save_and_disable_interrupts();
 
-  multicore_lockout_start_blocking(); // pause core1
+  if(core1_started)
+    multicore_lockout_start_blocking(); // pause core1
 
   if(offset == 0)
     flash_range_erase(storage_offset + sector * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
 
   flash_range_program(storage_offset + sector * FLASH_SECTOR_SIZE + offset, buffer, size_bytes);
 
-  multicore_lockout_end_blocking(); // resume core1
+  if(core1_started)
+    multicore_lockout_end_blocking(); // resume core1
 
   restore_interrupts(status);
 


### PR DESCRIPTION
Various scanvideo changes (some quite old):

- Moves scanline updates to core1 (more reliable timing)
- Fixes sync
- Partial `hires` support (can only have one mode, defaults to `lores`, `ALLOW_HIRES=1` switches to `hires`)

Last commit is a bit of a hack, but I used it to port DaftBoy. VGA still isn't very useful without the input stuff...