### PR TITLE
Pico examples changes

### DIFF
--- a/examples/platformer/CMakeLists.txt
+++ b/examples/platformer/CMakeLists.txt
@@ -4,3 +4,7 @@ find_package (32BLIT CONFIG REQUIRED PATHS ../..)
 blit_executable (platformer platformer.cpp)
 blit_assets_yaml (platformer assets.yml)
 blit_metadata (platformer metadata.yml)
+
+# This removes support for set_screen_mode(hires) for Pico-based devices
+# freeing up some extra RAM
+target_compile_definitions(platformer PRIVATE ALLOW_HIRES=0)

--- a/examples/tilt/CMakeLists.txt
+++ b/examples/tilt/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.9)
 project (tilt)
 find_package (32BLIT CONFIG REQUIRED PATHS ../..)
+
+if(32BLIT_PICO)
+    # No accelerometer
+    return()
+endif()
+
 blit_executable (tilt tilt.cpp)
 blit_metadata (tilt metadata.yml)


### PR DESCRIPTION
This disables the tilt example (doesn't do anything interesting) and sets `ALLOW_HIRES=0` for platformer. Both of these would fail to build with a 320x240 display.