### PR TITLE
stm32: work around QSPI failing to read the last 32 bytes

### DIFF
--- a/32blit-stm32/Src/quadspi.c
+++ b/32blit-stm32/Src/quadspi.c
@@ -33,7 +33,10 @@ void MX_QUADSPI_Init(void)
   hqspi.Init.ClockPrescaler = 2;
   hqspi.Init.FifoThreshold = 1;
   hqspi.Init.SampleShifting = QSPI_SAMPLE_SHIFTING_NONE;
-  hqspi.Init.FlashSize = QSPI_FLASH_SIZE;
+
+  // Use a flash size 2x what we should to avoid "Memory-mapped read of last memory byte fails"
+  // (due to prefetch, it's actually the last 32 bytes)
+  hqspi.Init.FlashSize = QSPI_FLASH_SIZE + 1;
   hqspi.Init.ChipSelectHighTime = QSPI_CS_HIGH_TIME_1_CYCLE;
   hqspi.Init.ClockMode = QSPI_CLOCK_MODE_3;
   hqspi.Init.FlashID = QSPI_FLASH_ID_2;


### PR DESCRIPTION

Example code:
```c
*(volatile uint8_t *)0x91FFFFE0; // boom, system gone
```

Locks up _everything_ including debugging...


Guess who spent most of the day debugging this :neutral_face:. (Not that I need those bytes, it was just a really weird crash to hit)

More info: https://www.st.com/resource/en/errata_sheet/es0396-stm32h750xb-and-stm32h753xi-device-limitations-stmicroelectronics.pdf#%5B%7B%22num%22%3A90%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C67%2C546%2Cnull%5D
