### PR TITLE
Rescan flash after flashing from SD

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -458,8 +458,10 @@ static bool launch_game_from_sd(const char *path, bool auto_delete = false) {
       cleanup_duplicates(meta, launch_offset);
   }
 
-  if(launch_offset == 0xFFFFFFFF)
+  if(launch_offset == 0xFFFFFFFF) {
     launch_offset = flash_from_sd_to_qspi_flash(file, flash_offset);
+    scan_flash();
+  }
 
   f_close(&file);
 


### PR DESCRIPTION
Found another case of not updating the game list... could result in duplicate games or not flashing new versions.