### PR TITLE
Update to latest SDL for macOS/Windows builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,7 +43,7 @@ jobs:
           - os: ubuntu-20.04
             name: MinGW
             cache-key: mingw
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/mingw.toolchain -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSDL2_DIR=$GITHUB_WORKSPACE/SDL2-2.0.10/x86_64-w64-mingw32/lib/cmake/SDL2/
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/mingw.toolchain -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSDL2_DIR=$GITHUB_WORKSPACE/SDL2/cmake -DSDL2_image_DIR=$GITHUB_WORKSPACE/SDL2_image/cmake -DSDL2_net_DIR=$GITHUB_WORKSPACE/SDL2_net/cmake
             apt-packages: ccache g++-mingw-w64 python3-setuptools
 
           - os: macos-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,6 +49,7 @@ jobs:
           - os: macos-latest
             name: macOS
             cache-key: macos
+            cmake-args: -DCMAKE_OSX_ARCHITECTURES=x86_64\;arm64
 
           - os: windows-latest
             name: Visual Studio

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
 		set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH}" "${ANDROID_LIB_DIR}/${ANDROID_ABI}") # won't search outside this
 	endif()
 
-	if(NOT SDL2_LIBRARIES OR NOT SDL2_INCLUDE_DIRS)
+	if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2::SDL2-static)
 		find_package(SDL2 REQUIRED)
 	endif()
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -13,6 +13,22 @@ add_library(BlitHalSDL STATIC
 function (find_sdl_lib lib_name header_name)
 	string(TOUPPER ${lib_name} VAR_PREFIX)
 
+	# new enough SDL_image/_net have cmake config support
+	find_package(${lib_name} QUIET)
+	if(TARGET ${lib_name}::${lib_name})
+		set(${VAR_PREFIX}_LIBRARY ${lib_name}::${lib_name} PARENT_SCOPE)
+		set(${VAR_PREFIX}_INCLUDE_DIR "" PARENT_SCOPE)
+
+		if(WIN32)
+			get_property(LIB_DLL TARGET ${lib_name}::${lib_name} PROPERTY IMPORTED_LOCATION)
+			set(${VAR_PREFIX}_DLL ${LIB_DLL} PARENT_SCOPE)
+		endif()
+
+		return()
+	endif()
+
+	message("find_package(${lib_name}) failed, trying manual search...")
+
 	find_path(${VAR_PREFIX}_INCLUDE_DIR ${header_name}
 		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
 		PATH_SUFFIXES SDL2 include/SDL2 include

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -34,23 +34,10 @@ function (find_sdl_lib lib_name header_name)
 		PATH_SUFFIXES SDL2 include/SDL2 include
 	)
 
-	# vs
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(VC_LIB_PATH_SUFFIX lib/x64)
-	else()
-		set(VC_LIB_PATH_SUFFIX lib/x86)
-	endif()
-
 	find_library(${VAR_PREFIX}_LIBRARY
 		NAMES ${lib_name}
 		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
-	)
-
-	# dlls
-	find_file(${VAR_PREFIX}_DLL ${lib_name}.dll
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
+		PATH_SUFFIXES lib
 	)
 
 	if(NOT ${VAR_PREFIX}_INCLUDE_DIR OR NOT ${VAR_PREFIX}_LIBRARY)

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -46,6 +46,10 @@ else()
 
 	# If SDL2 was built using CMake, the generated configuration files define SDL2::* targets instead of the SDL2_* variables
 	if(TARGET SDL2::SDL2)
+		if(NOT TARGET SDL2::SDL2main)
+			add_library(SDL2::SDL2main IMPORTED INTERFACE) # 2.24.0 is missing this target for macOS
+		endif()
+
 		set(SDL2_LIBRARIES SDL2::SDL2main SDL2::SDL2)
 	# handle SDL2 built with only a static library
 	elseif(TARGET SDL2::SDL2-static)

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -63,11 +63,6 @@ else()
 		set(SDL2_DIR "${32BLIT_DIR}/vs/sdl")
 	endif()
 
-	if(ANDROID AND NOT SDL2_DIR)
-		set(SDL2_DIR "${ANDROID_LIB_DIR}/${ANDROID_ABI}/lib/cmake/SDL2")
-		set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH}" "${ANDROID_LIB_DIR}/${ANDROID_ABI}") # won't search outside this
-	endif()
-
 	if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2::SDL2-static)
 		find_package(SDL2 REQUIRED)
 	endif()

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -218,10 +218,18 @@ function(blit_executable NAME SOURCES)
 	elseif(APPLE)
 		# TODO: this should be run in both cases to handle any other dependencies, but it fails on the SDL frameworks and there currently aren't any other deps...
 
+		set(SEARCH_DIRS)
+
+		# assuming all frameworks installed in the same place
+		if(SDL2_LIBRARIES MATCHES "\.framework$")
+			get_filename_component(FW_PARENT_DIR ${SDL2_LIBRARIES} DIRECTORY)
+			list(APPEND SEARCH_DIRS ${FW_PARENT_DIR})
+		endif()
+
 		file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/fixup.cmake
 			CONTENT "
 				include(BundleUtilities)
-				fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:${NAME}>.app\" \"\" \"\")
+				fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:${NAME}>.app\" \"\" \"${SEARCH_DIRS}\")
 			"
 		)
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -210,14 +210,7 @@ function(blit_executable NAME SOURCES)
 		)
 	endif()
 
-	if(APPLE AND SDL2_LIBRARIES MATCHES "\.framework$")
-	    # install the SDL frameworks
-		install(DIRECTORY ${SDL2_LIBRARIES} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
-		install(DIRECTORY ${SDL2_IMAGE_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
-		install(DIRECTORY ${SDL2_NET_LIBRARY} DESTINATION "bin/$<TARGET_FILE_NAME:${NAME}>.app/Contents/Frameworks")
-	elseif(APPLE)
-		# TODO: this should be run in both cases to handle any other dependencies, but it fails on the SDL frameworks and there currently aren't any other deps...
-
+	if(APPLE)
 		set(SEARCH_DIRS)
 
 		# assuming all frameworks installed in the same place

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -21,14 +21,6 @@ if(EMSCRIPTEN)
 
 	set(EMSCRIPTEN_SHELL ${CMAKE_CURRENT_SOURCE_DIR}/emscripten-shell.html PARENT_SCOPE)
 else()
-	# attempt to find the framework (find_package won't work as there's no config file)
-	if(APPLE)
-		find_library(SDL2_LIBRARIES NAMES SDL2)
-
-		find_path(SDL2_INCLUDE_DIRS NAMES SDL.h
-			PATHS ~/Library/Frameworks /Library/Frameworks
-		)
-	endif()
 
 	# fallback guess for SDL location on Windows
 	if(WIN32 AND NOT SDL2_DIR AND 32BLIT_DIR)
@@ -42,6 +34,10 @@ else()
 
 	if(NOT SDL2_LIBRARIES OR NOT SDL2_INCLUDE_DIRS)
 		find_package(SDL2 REQUIRED)
+	endif()
+
+	if(SDL2_FRAMEWORK_PATH)
+		set(SDL2_FRAMEWORK_PATH ${SDL2_FRAMEWORK_PATH} PARENT_SCOPE)
 	endif()
 
 	# If SDL2 was built using CMake, the generated configuration files define SDL2::* targets instead of the SDL2_* variables
@@ -214,8 +210,8 @@ function(blit_executable NAME SOURCES)
 		set(SEARCH_DIRS)
 
 		# assuming all frameworks installed in the same place
-		if(SDL2_LIBRARIES MATCHES "\.framework$")
-			get_filename_component(FW_PARENT_DIR ${SDL2_LIBRARIES} DIRECTORY)
+		if(SDL2_FRAMEWORK_PATH)
+			get_filename_component(FW_PARENT_DIR ${SDL2_FRAMEWORK_PATH} DIRECTORY)
 			list(APPEND SEARCH_DIRS ${FW_PARENT_DIR})
 		endif()
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -10,6 +10,39 @@ add_library(BlitHalSDL STATIC
 	System.cpp
 )
 
+function (find_sdl_lib lib_name header_name)
+	string(TOUPPER ${lib_name} VAR_PREFIX)
+
+	find_path(${VAR_PREFIX}_INCLUDE_DIR ${header_name}
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
+		PATH_SUFFIXES SDL2 include/SDL2 include
+	)
+
+	# vs
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(VC_LIB_PATH_SUFFIX lib/x64)
+	else()
+		set(VC_LIB_PATH_SUFFIX lib/x86)
+	endif()
+
+	find_library(${VAR_PREFIX}_LIBRARY
+		NAMES ${lib_name}
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
+		PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+	)
+
+	# dlls
+	find_file(${VAR_PREFIX}_DLL ${lib_name}.dll
+		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
+		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
+	)
+
+	if(NOT ${VAR_PREFIX}_INCLUDE_DIR OR NOT ${VAR_PREFIX}_LIBRARY)
+		message(FATAL_ERROR "${lib_name} not found!")
+	endif()
+
+endfunction()
+
 if(EMSCRIPTEN)
 	target_compile_options(BlitHalSDL
 		PRIVATE -sUSE_SDL=2 -sUSE_SDL_IMAGE=2 -sUSE_SDL_NET=2
@@ -57,56 +90,8 @@ else()
 	endif()
 
 	# find SDL2_image
-	# TODO: may need to be more complicated
-	find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES SDL2 include/SDL2 include
-	)
-
-	# vs
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(VC_LIB_PATH_SUFFIX lib/x64)
-	else()
-		set(VC_LIB_PATH_SUFFIX lib/x86)
-	endif()
-
-	find_library(SDL2_IMAGE_LIBRARY
-		NAMES SDL2_image
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
-	)
-
-	# dlls
-	find_file(SDL2_IMAGE_DLL SDL2_image.dll
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
-	)
-
-	#SDL_net
-	find_path(SDL2_NET_INCLUDE_DIR SDL_net.h
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES SDL2 include/SDL2 include
-	)
-
-	find_library(SDL2_NET_LIBRARY
-		NAMES SDL2_net
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
-	)
-
-	# dlls
-	find_file(SDL2_NET_DLL SDL2_net.dll
-		HINTS ${SDL2_DIR} ${SDL2_DIR}/../../../
-		PATH_SUFFIXES bin ${VC_LIB_PATH_SUFFIX}
-	)
-
-	if(NOT SDL2_IMAGE_INCLUDE_DIR OR NOT SDL2_IMAGE_LIBRARY)
-		message(FATAL_ERROR "SDL_image not found!")
-	endif()
-
-	if(NOT SDL2_NET_INCLUDE_DIR OR NOT SDL2_NET_LIBRARY)
-		message(FATAL_ERROR "SDL_net not found!")
-	endif()
+	find_sdl_lib(SDL2_image SDL_image.h)
+	find_sdl_lib(SDL2_net SDL_net.h)
 
 	target_include_directories(BlitHalSDL
 		PRIVATE	${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_NET_INCLUDE_DIR}

--- a/ci/install_sdl_macos.sh
+++ b/ci/install_sdl_macos.sh
@@ -1,7 +1,7 @@
 if [ ! -f ~/Library/Frameworks/SDL2_net.framework/SDL2_net ]; then
-    curl https://libsdl.org/release/SDL2-2.0.10.dmg -o SDL2.dmg
-    curl http://libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.dmg -o SDL2_image.dmg
-    curl http://libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.dmg -o SDL2_net.dmg
+    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-2.24.0.dmg -o SDL2.dmg
+    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-2.6.2.dmg -o SDL2_image.dmg
+    curl -L https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-2.2.0.dmg -o SDL2_net.dmg
 
     hdiutil mount SDL2.dmg
     hdiutil mount SDL2_image.dmg

--- a/ci/install_sdl_mingw.sh
+++ b/ci/install_sdl_mingw.sh
@@ -1,16 +1,14 @@
-if [ ! -f SDL2_net-2.0.1/README.txt ]; then
-    curl https://libsdl.org/release/SDL2-devel-2.0.10-mingw.tar.gz -o SDL2.tar.gz
-    curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz -o SDL2_image.tar.gz
-    curl https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-mingw.tar.gz -o SDL2_net.tar.gz
+if [ ! -f SDL2_net/README.txt ]; then
+    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-mingw.tar.gz -o SDL2.tar.gz
+    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-devel-2.6.2-mingw.tar.gz -o SDL2_image.tar.gz
+    curl -L https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-mingw.tar.gz -o SDL2_net.tar.gz
 
     tar -xf SDL2.tar.gz
     tar -xf SDL2_image.tar.gz
     tar -xf SDL2_net.tar.gz
 
-    # fix the path in the cmake config
-    sed -i "s|/opt/local|$PWD/SDL2-2.0.10|g" ./SDL2-2.0.10/x86_64-w64-mingw32/lib/cmake/SDL2/sdl2-config.cmake
-
-    # copy SDL2_image/net into SDL2
-    cp -r ./SDL2_image-2.0.5/x86_64-w64-mingw32 ./SDL2-2.0.10/
-    cp -r ./SDL2_net-2.0.1/x86_64-w64-mingw32 ./SDL2-2.0.10/
+    # remove the version
+    mv SDL2-2.24.0 SDL2
+    mv SDL2_image-2.6.2 SDL2_image
+    mv SDL2_net-2.2.0 SDL2_net
 fi

--- a/ci/install_sdl_vs.sh
+++ b/ci/install_sdl_vs.sh
@@ -1,14 +1,14 @@
 if [ ! -f vs/sdl/include/SDL_net.h ]; then
-    curl https://libsdl.org/release/SDL2-devel-2.0.10-VC.zip -o SDL2.zip
-    curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-VC.zip -o SDL2_image.zip
-    curl https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-VC.zip -o SDL2_net.zip
+    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-VC.zip -o SDL2.zip
+    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-devel-2.6.2-VC.zip -o SDL2_image.zip
+    curl -L https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-VC.zip -o SDL2_net.zip
 
     unzip SDL2.zip -d vs/sdl
     unzip -o SDL2_image.zip -d vs/sdl
     unzip -o SDL2_net.zip -d vs/sdl
 
     # move dirs up
-    mv vs/sdl/SDL2-2.0.10/* vs/sdl
-    cp -r vs/sdl/SDL2_image-2.0.5/* vs/sdl
-    cp -r vs/sdl/SDL2_net-2.0.1/* vs/sdl
+    mv vs/sdl/SDL2-2.24.0/* vs/sdl
+    cp -r vs/sdl/SDL2_image-2.6.2/* vs/sdl
+    cp -r vs/sdl/SDL2_net-2.2.0/* vs/sdl
 fi

--- a/docs/Windows-VisualStudio.md
+++ b/docs/Windows-VisualStudio.md
@@ -18,7 +18,7 @@ You will need Visual Studio 2019 (preferably version 16.4).
 
 Make sure you install C++ desktop development support.
 
-You will also need to download SDL2 development libraries from the [SDL homepage](https://www.libsdl.org/download-2.0.php). Here find the latest version of the VC development libraries (at the time of this writing SDL2-devel-2.0.10-VC.zip). Additionally, download SDL2_image from [here](https://www.libsdl.org/projects/SDL_image/) (SDL2_image-devel-2.0.5-VC.zip) and SDL2_net from [here](https://www.libsdl.org/projects/SDL_net/) (SDL2_net-devel-2.0.1-VC.zip).
+You will also need to download SDL2 development libraries from the [SDL releases](https://github.com/libsdl-org/SDL/releases/latest). Here find the latest version of the VC development libraries (at the time of this writing SDL2-devel-2.24.0-VC.zip). Additionally, download SDL2_image from [here](https://github.com/libsdl-org/SDL_image/releases/latest) (SDL2_image-devel-2.6.1-VC.zip) and SDL2_net from [here](https://github.com/libsdl-org/SDL_net/releases/latest) (SDL2_net-devel-2.2.0-VC.zip).
 
 Place these in the `vs\sdl\` folder. You will need to merge the include/lib directories. If you are using CMake/Open Folder, these are downloaded automatically.
 

--- a/docs/Windows-WSL.md
+++ b/docs/Windows-WSL.md
@@ -84,9 +84,9 @@ sudo mkdir -p /opt/local/
 Grab and install the SDL2 mingw development package:
 
 ```shell
-wget https://libsdl.org/release/SDL2-devel-2.0.10-mingw.tar.gz
-tar xzf SDL2-devel-2.0.10-mingw.tar.gz
-sudo cp -r SDL2-2.0.10/x86_64-w64-mingw32 /opt/local/
+wget https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-mingw.tar.gz 
+tar xzf SDL2-devel-2.24.0-mingw.tar.gz
+sudo cp -r SDL2-2.24.0/x86_64-w64-mingw32 /opt/local/
 ```
 
 #### SDL2_image
@@ -94,9 +94,9 @@ sudo cp -r SDL2-2.0.10/x86_64-w64-mingw32 /opt/local/
 Grab and install the SDL2_image mingw development package:
 
 ```shell
-wget https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz
-tar xzf SDL2_image-devel-2.0.5-mingw.tar.gz
-sudo cp -r SDL2_image-2.0.5/x86_64-w64-mingw32 /opt/local/
+wget https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-devel-2.6.2-mingw.tar.gz
+tar xzf SDL2_image-devel-2.6.2-mingw.tar.gz
+sudo cp -r SDL2_image-2.6.2/x86_64-w64-mingw32 /opt/local/
 ```
 
 #### SDL2_net
@@ -104,9 +104,9 @@ sudo cp -r SDL2_image-2.0.5/x86_64-w64-mingw32 /opt/local/
 Grab and install the SDL2_net mingw development package:
 
 ```shell
-wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-mingw.tar.gz
-tar xzf SDL2_net-devel-2.0.1-mingw.tar.gz
-sudo cp -r SDL2_net-2.0.1/x86_64-w64-mingw32 /opt/local/
+wget https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-mingw.tar.gz
+tar xzf SDL2_net-devel-2.2.0-mingw.tar.gz
+sudo cp -r SDL2_net-2.2.0/x86_64-w64-mingw32 /opt/local/
 ```
 
 ### Building

--- a/vs/sdl/README.md
+++ b/vs/sdl/README.md
@@ -1,8 +1,8 @@
 # SDL2 Binaries for Visual Studio Builds
 
-Download the SDL2 development libraries from the [SDL homepage](https://www.libsdl.org/download-2.0.php). You should find the latest version of the VC development libraries (at the time of writing these are SDL2-devel-2.0.10-VC.zip).
+Download the SDL2 development libraries from the [SDL releases](https://github.com/libsdl-org/SDL/releases/latest). You should find the latest version of the VC development libraries (at the time of writing these are SDL2-devel-2.24.0-VC.zip).
 
-Also, Download the SDL2_image development libraries from the [SDL_image homepage](https://www.libsdl.org/projects/SDL_image/). (At the time of writing the latest version is SDL2_image-devel-2.0.5-VC.zip).
+Also, Download the SDL2_image development libraries from the [SDL_image releases](https://github.com/libsdl-org/SDL_image/releases/latest). (At the time of writing the latest version is SDL2_image-devel-2.6.2-VC.zip).
 
 Once extracted you should ensure the SDL "include" and "lib" directories are directly in `vs/sdl`. The tree should look like:
 

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -47,18 +47,5 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
 
 endif()
 
-set(SDL2_INCLUDE_DIRS "${SDL2_DIR}/include")
-
-if(CMAKE_GENERATOR_PLATFORM)
-    set(SDL2_LIBDIR "${SDL2_DIR}/lib/${CMAKE_GENERATOR_PLATFORM}")
-else()
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(SDL2_LIBDIR "${SDL2_DIR}/lib/x64/")
-    else()
-        set(SDL2_LIBDIR "${SDL2_DIR}/lib/x86/")
-    endif()
-endif()
-
-set(SDL2_LIBRARIES "${SDL2_LIBDIR}/SDL2.lib" "${SDL2_LIBDIR}/SDL2main.lib")
-
-set(SDL2_DLL "${SDL2_LIBDIR}/SDL2.dll")
+include(${CMAKE_CURRENT_LIST_DIR}/SDL2-2.24.0/cmake/sdl2-config.cmake)
+get_property(SDL2_DLL TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION)

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -17,35 +17,38 @@ function(fetch_sdl2_library directory url filename hash)
     # file(ARCHIVE_EXTRACT INPUT ${filename})
 endfunction(fetch_sdl2_library)
 
+set(SDL2_VERSION 2.24.0)
+set(SDL2_IMAGE_VERSION 2.6.2)
+set(SDL2_NET_VERSION 2.2.0)
 
 if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
 
     fetch_sdl2_library(
-        SDL2-2.24.0
-        https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/
-        SDL2-devel-2.24.0-VC.zip
+        SDL2-${SDL2_VERSION}
+        https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/
+        SDL2-devel-${SDL2_VERSION}-VC.zip
         8a54459189e88c30ba024ee5f18ce4b1a5d1d9e7
     )
 
     fetch_sdl2_library(
-        SDL2_image-2.6.2
-        https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/
-        SDL2_image-devel-2.6.2-VC.zip
+        SDL2_image-${SDL2_IMAGE_VERSION}
+        https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/
+        SDL2_image-devel-${SDL2_IMAGE_VERSION}-VC.zip
         4111affcca1f4b41c2f4b4c445ccf06fe081b5e9
     )
 
     fetch_sdl2_library(
-        SDL2_net-2.2.0
-        https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/
-        SDL2_net-devel-2.2.0-VC.zip
+        SDL2_net-${SDL2_NET_VERSION}
+        https://github.com/libsdl-org/SDL_net/releases/download/release-${SDL2_NET_VERSION}/
+        SDL2_net-devel-${SDL2_NET_VERSION}-VC.zip
         c8ff358a5c8338002b05ab6de7ce91ee1c86bd45
     )
 
 endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/SDL2-2.24.0/cmake/sdl2-config.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/SDL2-${SDL2_VERSION}/cmake/sdl2-config.cmake)
 get_property(SDL2_DLL TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION)
 
 # help cmake to find the other libs
-set(SDL2_image_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_image-2.6.2/cmake)
-set(SDL2_net_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_net-2.2.0/cmake)
+set(SDL2_image_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_image-${SDL2_IMAGE_VERSION}/cmake)
+set(SDL2_net_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_net-${SDL2_NET_VERSION}/cmake)

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -25,24 +25,24 @@ endfunction(fetch_sdl2_library)
 if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
 
     fetch_sdl2_library(
-        SDL2-2.0.12
-        https://www.libsdl.org/release/
-        SDL2-devel-2.0.12-VC.zip
-        6839b6ec345ef754a6585ab24f04e125e88c3392
+        SDL2-2.24.0
+        https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/
+        SDL2-devel-2.24.0-VC.zip
+        8a54459189e88c30ba024ee5f18ce4b1a5d1d9e7
     )
 
     fetch_sdl2_library(
-        SDL2_image-2.0.5
-        https://www.libsdl.org/projects/SDL_image/release/
-        SDL2_image-devel-2.0.5-VC.zip
-        137f86474691f4e12e76e07d58d5920c8d844d5b
+        SDL2_image-2.6.2
+        https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/
+        SDL2_image-devel-2.6.2-VC.zip
+        4111affcca1f4b41c2f4b4c445ccf06fe081b5e9
     )
 
     fetch_sdl2_library(
-        SDL2_net-2.0.1
-        https://www.libsdl.org/projects/SDL_net/release/
-        SDL2_net-devel-2.0.1-VC.zip
-        90adcf4d0d17aed26c1e56ade159d90db4b98b54
+        SDL2_net-2.2.0
+        https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/
+        SDL2_net-devel-2.2.0-VC.zip
+        c8ff358a5c8338002b05ab6de7ce91ee1c86bd45
     )
 
 endif()

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -49,3 +49,7 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/SDL2-2.24.0/cmake/sdl2-config.cmake)
 get_property(SDL2_DLL TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION)
+
+# help cmake to find the other libs
+set(SDL2_image_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_image-2.6.2/cmake)
+set(SDL2_net_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_net-2.2.0/cmake)

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -15,10 +15,6 @@ function(fetch_sdl2_library directory url filename hash)
     endif()
     # in future we might be able to use:
     # file(ARCHIVE_EXTRACT INPUT ${filename})
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/include
-        DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/${directory}/lib
-        DESTINATION ${CMAKE_CURRENT_LIST_DIR}/)
 endfunction(fetch_sdl2_library)
 
 

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -6,9 +6,9 @@ function(fetch_sdl2_library directory url filename hash)
             TIMEOUT 120
             EXPECTED_HASH SHA1=${hash}
             TLS_VERIFY ON)
-        message(STATUS "Extracting ${filename}")
     endif()
     if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/${directory})
+        message(STATUS "Extracting ${filename}")
         # tar -xf should work on Windows 10 build 17063 or later (Dec 2017)
         execute_process(COMMAND tar -xf ${filename}
                         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
This started as an attempt to work around build failures on macOS, then turned into "I wonder if I can clean this up by updating"... and then resulted in [android boilerplate for some reason](https://github.com/32blit/32blit-boilerplate/compare/main...Daft-Freak:32blit-boilerplate:android).

First three are fixes and could be split if we just want fixes for now. Then, macOS/Windows (VS+MinGW) SDL versions are updated which allows some simplification as they both support `find_package` now. 

There's some cleanup to make macOS frameworks slightly less special, the VS script doesn't create two copies of the headers/libs and the MinGW script no longer needs to patch the config.

2c89fb106a779b80e258e75108b3433bf379d609 and 96a175fa266e25e1ca613bd2ee1ca79fa443a599 allow [including SDL sources before the SDK](https://github.com/Daft-Freak/32blit-boilerplate/blob/android/android-project/app/jni/CMakeLists.txt), which is handy for platforms that don't have a prebuilt version available.

Oh, and I actually updated the docs this time. (Fixing the SDL download links as well)

(Probably replaces #483)