### PR TITLE
Minor firmware blit flashing improvements

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -403,7 +403,8 @@ static uint32_t flash_from_sd_to_qspi_flash(FIL &file, uint32_t flash_offset) {
 
 // runs a .blit file, flashing it if required
 static bool launch_game_from_sd(const char *path, bool auto_delete = false) {
-  if(is_qspi_memorymapped()) {
+  bool qspi_was_mapped = is_qspi_memorymapped();
+  if(qspi_was_mapped) {
     qspi_disable_memorymapped_mode();
     blit_disable_user_code(); // assume user running
   }
@@ -462,6 +463,8 @@ static bool launch_game_from_sd(const char *path, bool auto_delete = false) {
 
     return blit_switch_execution(launch_offset, true);
   }
+  else if(qspi_was_mapped)
+    qspi_enable_memorymapped_mode();
 
   blit_enable_user_code();
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -129,6 +129,8 @@ static bool parse_file_metadata(FIL &fh, GameInfo &info) {
   if(header.magic != blit_game_magic)
     return false;
 
+  info.size = header.end - qspi_flash_address;
+
   bool result = false;
 
   // get metadata

--- a/firmware/firmware.hpp
+++ b/firmware/firmware.hpp
@@ -41,7 +41,7 @@ struct {
       screen.rectangle(Rect(0, screen.bounds.h - 25, screen.bounds.w, 25));
       screen.pen = Pen(255, 255, 255);
       screen.text(this->message, minimal_font, Point(5, screen.bounds.h - 20));
-      uint32_t progress_width = (uint64_t(this->value) * (screen.bounds.w - 10)) / this->total;
+      uint32_t progress_width = float(this->value) / this->total * (screen.bounds.w - 10);
       screen.rectangle(Rect(5, screen.bounds.h - 10, progress_width, 5));
     }
   }

--- a/firmware/firmware.hpp
+++ b/firmware/firmware.hpp
@@ -41,7 +41,7 @@ struct {
       screen.rectangle(Rect(0, screen.bounds.h - 25, screen.bounds.w, 25));
       screen.pen = Pen(255, 255, 255);
       screen.text(this->message, minimal_font, Point(5, screen.bounds.h - 20));
-      uint32_t progress_width = ((this->value * (screen.bounds.w - 10)) / this->total);
+      uint32_t progress_width = (uint64_t(this->value) * (screen.bounds.w - 10)) / this->total;
       screen.rectangle(Rect(5, screen.bounds.h - 10, progress_width, 5));
     }
   }

--- a/launcher-shared/dialog.hpp
+++ b/launcher-shared/dialog.hpp
@@ -9,9 +9,11 @@ struct Dialog {
   AnswerFunc on_answer;
   bool is_question;
 
+  static constexpr Rect dialog_rect{45, 77, 230, 85};
+
   void show(std::string title, std::string message, AnswerFunc on_answer, bool is_question = true) {
     this->title = title;
-    this->message = message;
+    this->message = screen.wrap_text(message, dialog_rect.w - 12, minimal_font);
     this->on_answer = on_answer;
     this->is_question = is_question;
   }
@@ -56,7 +58,6 @@ struct Dialog {
     if(title.empty())
       return;
 
-    const Rect dialog_rect(45, 77, 230, 85);
     const int header_height = 16;
 
     screen.pen = Pen(235, 245, 255);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -703,7 +703,8 @@ void update(uint32_t time) {
         currentScreen = Screen::screenshot;
       }
       else {
-        launch_current_game();
+        if(!launch_current_game())
+          dialog.show("Error!", "Failed to launch " + selected_game.filename, [](bool){}, false);
       }
     }
   }


### PR DESCRIPTION
First half: fixes some issues with failed flashes. Second half: use file size from headers instead of the actual file size.

- Fixes a crash when flashing a .blit fails
- Prevents overwriting things stored at the start of flash when running low on space (or trying to flash something unreasonably big)
- Simplifies size calc a little and is consistent with the size used after the file is flashed

A side effect of this is that you can append extra data to the end of a .blit and the flashing code ignores it (at least when loading from the SD card). Previously it would get flashed, but would likely get another .blit flashed on top of it later.