### PR TITLE
Update actions for deprecation warnings

### DIFF
--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install deps
       run: |
@@ -28,7 +28,7 @@ jobs:
 
     - name: Setup cache
       id: cache-system-libraries
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{env.EM_CACHE_FOLDER}}
         key: ${{env.EM_VERSION}}-${{runner.os}}

--- a/.github/workflows/Visual Studio.yml
+++ b/.github/workflows/Visual Studio.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install 32blit
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Build
       run: msbuild.exe vs/32blit.sln

--- a/.github/workflows/Visual Studio.yml
+++ b/.github/workflows/Visual Studio.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install deps
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,12 +64,12 @@ jobs:
 
     steps:
     - name: Checkout 32Blit SDK
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # pico sdk/extras for some builds
     - name: Checkout Pico SDK
       if: matrix.pico-sdk
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: raspberrypi/pico-sdk
         path: pico-sdk
@@ -77,13 +77,13 @@ jobs:
 
     - name: Checkout Pico Extras
       if: matrix.pico-sdk
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: raspberrypi/pico-extras
         path: pico-extras
 
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /home/runner/.ccache
         key: ccache-${{matrix.cache-key}}-${{github.ref}}-${{github.sha}}


### PR DESCRIPTION
Fixes these:
![deprecation warnings](https://user-images.githubusercontent.com/3074891/205054164-69df37e6-634e-472f-9392-7c594310f29e.png)
(repeat for other builds)

... except for one warning left on the Emscripten build.

Boilerplate: https://github.com/32blit/32blit-boilerplate/pull/25