### PR TITLE
Update GCC version in linux docs

### DIFF
--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -21,7 +21,7 @@ For local builds:
  - SDL2 + SDL2_image + SDL2_net
 
 For 32Blit device builds:
- - Arm Embedded GCC (`gcc-arm-none-eabi`, versions 7.x-9.x should work)
+ - Arm Embedded GCC (`gcc-arm-none-eabi`, versions 8.x-12.x should work)
 
 New enough versions of these exist in at least Debian "buster" and Ubuntu 20.04.
 


### PR DESCRIPTION
After #788, 11/12 should work. 7.x wasn't tested and even debian stable has 8.x now.