### PR TITLE
stm32: remove readelf from post build commands

### DIFF
--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -7,7 +7,6 @@ function(blit_executable_common NAME)
 	set_property(TARGET ${NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-Map=${NAME}.map,--cref")
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.bin"
-		COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${NAME}> ${NAME}.hex
 		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}> ${NAME}.bin
 		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}>
 	)

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -10,7 +10,6 @@ function(blit_executable_common NAME)
 		COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${NAME}> ${NAME}.hex
 		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}> ${NAME}.bin
 		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}>
-		COMMAND ${CMAKE_READELF} -S $<TARGET_FILE:${NAME}>
 	)
 endfunction()
 


### PR DESCRIPTION
Adds a lot of noise to build output for information that isn't useful most of the time. (`size` providing most of the useful info)

Leaving the .hex output, which is also of questionable usefulness...