### PR TITLE
Remember launched item in launcher + font changes

### DIFF
--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -315,6 +315,9 @@ void load_current_game_metadata() {
 }
 
 bool launch_current_game() {
+  if(!api.launch)
+    return false;
+
   return api.launch(selected_game.filename.c_str());
 }
 

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -569,9 +569,9 @@ void render(uint32_t time) {
     screen.pen = theme.color_text;
 
     if(/*current_directory->name != "FLASH" &&*/ !blit::is_storage_available())
-      screen.text("No SD Card\nDetected.", minimal_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);
+      screen.text("No SD Card\nDetected.", launcher_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);
     else
-      screen.text("No Games Found.", minimal_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);
+      screen.text("No Games Found.", launcher_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);
   }
 
   if (currentScreen == Screen::credits) {

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -114,7 +114,7 @@ void load_directory_list(const std::string &directory) {
   int x = 0;
   for(auto &dir : directory_list) {
     dir.x = x;
-    dir.w = screen.measure_text(dir.name == "/" ? "ROOT" : dir.name, minimal_font).w;
+    dir.w = screen.measure_text(dir.name == "/" ? "ROOT" : dir.name, launcher_font).w;
 
     x += dir.w + 10;
   }
@@ -478,7 +478,7 @@ void render(uint32_t time) {
   }
 
   // adjust alignment rect for vertical spacing
-  const int text_align_height = ROW_HEIGHT + minimal_font.spacing_y;
+  const int text_align_height = ROW_HEIGHT + launcher_font.spacing_y;
 
   // list folders
   if(!directory_list.empty()) {
@@ -491,7 +491,7 @@ void render(uint32_t time) {
         screen.pen = theme.color_text;
 
       int x = 120 + 95 + directory.x - directory_list_scroll_offset;
-      screen.text(directory.name == "/" ? "ROOT" : directory.name, minimal_font, Rect(x, 5, 190, text_align_height), true, TextAlign::center_v);
+      screen.text(directory.name == "/" ? "ROOT" : directory.name, launcher_font, Rect(x, 5, 190, text_align_height), true, TextAlign::center_v);
     }
 
     screen.clip = Rect(Point(0, 0), screen.bounds);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -545,7 +545,7 @@ void render(uint32_t time) {
         screen.blit(selected_game_metadata.splash, Rect(Point(0, 0), selected_game_metadata.splash->bounds), game_info_offset);
 
       screen.pen = theme.color_accent;
-      std::string wrapped_title = screen.wrap_text(selected_game_metadata.title, screen.bounds.w - game_info_offset.x - 10, minimal_font);
+      std::string wrapped_title = screen.wrap_text(selected_game_metadata.title, screen.bounds.w - game_info_offset.x - 10, launcher_font);
 
       Size title_size = screen.measure_text(wrapped_title, launcher_font);
       screen.text(wrapped_title, launcher_font, Point(game_info_offset.x, game_info_offset.y + 104));


### PR DESCRIPTION
Saves the path of the last file to be launched and scrolls the file/folder lists back there when restarting the launcher. Also used the same font for the folder list as the file list... and a few minor things.

I think we used to have this back before the launcher was a separate thing, and it was annoying me recently. (Trying to test a big list of blits)