### PR TITLE
Fix builds using pico.toochain with SDK 1.5.0

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -7,6 +7,11 @@ pico_sdk_init()
 
 set(32BLIT_PICO 1 PARENT_SCOPE)
 
+# prevent find_package errors in pico_add_uf2_output later
+set(PICO_SDK_VERSION_MAJOR ${PICO_SDK_VERSION_MAJOR} PARENT_SCOPE)
+set(PICO_SDK_VERSION_MINOR ${PICO_SDK_VERSION_MINOR} PARENT_SCOPE)
+set(PICO_SDK_VERSION_REVISION ${PICO_SDK_VERSION_REVISION} PARENT_SCOPE)
+
 add_library(BlitHalPico INTERFACE)
 target_sources(BlitHalPico INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/../3rd-party/fatfs/ff.c


### PR DESCRIPTION
The blit SDK itself is not affected by this as it includes the pico-sdk import in the root CMakeLists. Anything using the toolchain file (like the boilerplate) is a bit broken.

Prevents errors like:
```
[cmake] CMake Error at /home/daftfreak/workspace/pico/pico-sdk/tools/CMakeLists.txt:61 (find_package):
[cmake]   find_package called with invalid argument ".."
[cmake] Call Stack (most recent call first):
[cmake]   /home/daftfreak/workspace/pico/pico-sdk/src/rp2_common.cmake:47 (pico_add_uf2_output)
[cmake]   32blit-pico/CMakeLists.txt:140 (pico_add_extra_outputs)
[cmake]   32blit-pico/CMakeLists.txt:148 (blit_executable_int_flash)
```