### PR TITLE
Only build picosystem hardware test for picosystem

### DIFF
--- a/examples/hardware-test/CMakeLists.txt
+++ b/examples/hardware-test/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 project (hardware-test)
 find_package (32BLIT CONFIG REQUIRED PATHS ../..)
 
-if(32BLIT_PICO)
+if(PICO_BOARD STREQUAL "pimoroni_picosystem")
     # PicoSystem has its own picosystem-hardware-test
     return()
 endif()

--- a/examples/picosystem-hardware-test/CMakeLists.txt
+++ b/examples/picosystem-hardware-test/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 project (picosystem-hardware-test)
 find_package (32BLIT CONFIG REQUIRED PATHS ../..)
 
-if(NOT 32BLIT_PICO)
+if(NOT PICO_BOARD STREQUAL "pimoroni_picosystem")
     # Hooks into the Pico SDK to get battery charge and VBUS status
     return()
 endif()


### PR DESCRIPTION
Running it on non-picosystem things can result in some brokenness due to the GPIO stuff. (Make me think I've broken VGA more than once...)