### PR TITLE
Avoid DMA channel/PIO SM conflicts from scanvideo/audio

### DIFF
--- a/32blit-pico/display_scanvideo.cpp
+++ b/32blit-pico/display_scanvideo.cpp
@@ -47,6 +47,9 @@ void init_display() {
   // channel 0 get claimed later, channel 3 doesn't get claimed, but does get used
   // reserve them so out claims don't conflict
   dma_claim_mask(1 << 0 | 1 << 3);
+
+  // PIO SMs that get claimed later
+  pio_claim_sm_mask(pio0, 1 << 0 | 1 << 3);
 }
 
 void update_display(uint32_t time) {
@@ -60,6 +63,8 @@ void update_display(uint32_t time) {
 
 void init_display_core1() {
   dma_unclaim_mask(1 << 0 | 1 << 3);
+  pio_sm_unclaim(pio0,  0);
+  pio_sm_unclaim(pio0,  3);
 
   // no mode switching yet
 #if ALLOW_HIRES

--- a/32blit-pico/display_scanvideo.cpp
+++ b/32blit-pico/display_scanvideo.cpp
@@ -1,6 +1,7 @@
 #include "display.hpp"
 
 #include "hardware/clocks.h"
+#include "hardware/dma.h"
 #include "pico/time.h"
 #include "pico/scanvideo.h"
 #include "pico/scanvideo/composable_scanline.h"
@@ -43,7 +44,9 @@ static void fill_scanline_buffer(struct scanvideo_scanline_buffer *buffer) {
 }
 
 void init_display() {
-
+  // channel 0 get claimed later, channel 3 doesn't get claimed, but does get used
+  // reserve them so out claims don't conflict
+  dma_claim_mask(1 << 0 | 1 << 3);
 }
 
 void update_display(uint32_t time) {
@@ -56,6 +59,8 @@ void update_display(uint32_t time) {
 }
 
 void init_display_core1() {
+  dma_unclaim_mask(1 << 0 | 1 << 3);
+
   // no mode switching yet
 #if ALLOW_HIRES
 #if DISPLAY_HEIGHT == 160 // extra middle mode

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -198,6 +198,7 @@ int main() {
   init_input();
   init_fs();
   init_usb();
+  init_audio();
 
 #if defined(ENABLE_CORE1)
   multicore_launch_core1(core1_main);
@@ -207,8 +208,6 @@ int main() {
 
   blit::render = ::render;
   blit::update = ::update;
-
-  init_audio();
 
   // user init
   ::init();


### PR DESCRIPTION
This is a bit of a hack due to pico-extras not using `*_claim_unused_*` (scanvideo using hardcoded numbers). Avoids more hardcoding/hacks in the SD card and DVI code.