### PR TITLE
Launcher refactoring

### DIFF
--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -391,6 +391,13 @@ void init() {
   set_screen_mode(ScreenMode::hires);
   screen.clear();
 
+  // shrink the filename column on narrower screens
+  if(screen.bounds.w < game_actions_offset.x + 24) {
+    int diff = (game_actions_offset.x + 24) - screen.bounds.w;
+    game_info_offset.x -= diff;
+    game_actions_offset.x -= diff;
+  }
+
   selected_menu_item = 0;
 
   init_theme();

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -58,7 +58,9 @@ AutoRepeat ar_button_down(250, 600);
 AutoRepeat ar_button_left(0, 0);
 AutoRepeat ar_button_right(0, 0);
 
+#ifndef PICO_BUILD
 uint8_t screenshot_buf[320 * 240 * 3];
+#endif
 
 int calc_num_blocks(uint32_t size) {
   return (size - 1) / qspi_flash_sector_size + 1;
@@ -293,6 +295,7 @@ void load_current_game_metadata() {
       loaded = parse_file_metadata(selected_game.filename, selected_game_metadata, true);
   }
 
+#ifndef PICO_BUILD
   if(selected_game.type == GameType::screenshot) {
     if(selected_game.filename != current_screenshot) {
       // Free any old buffers
@@ -312,6 +315,7 @@ void load_current_game_metadata() {
       screenshot = nullptr;
     }
   }
+#endif
 
   // no valid metadata, reset
   if(!loaded) {

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -668,6 +668,9 @@ void update(uint32_t time) {
   bool button_left = ar_button_left.next(time, buttons.state & Button::DPAD_LEFT || joystick.x < -0.5f);
   bool button_right = ar_button_right.next(time, buttons.state & Button::DPAD_RIGHT || joystick.x > 0.5f);
 
+  if(dialog.update())
+    return;
+
   if (current_screen == Screen::credits) {
     credits::update(time);
 
@@ -686,9 +689,6 @@ void update(uint32_t time) {
     credits::reset_scrolling();
     current_screen = Screen::credits;
   }
-
-  if(dialog.update())
-    return;
 
   int total_items = (int)game_list.size();
 

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -204,6 +204,7 @@ void load_file_list(const std::string &directory) {
 
     if(!api.get_type_handler_metadata) continue;
 
+    // check for installed handler
     auto handler_meta = api.get_type_handler_metadata(ext.c_str());
 
     if(handler_meta) {
@@ -215,7 +216,7 @@ void load_file_list(const std::string &directory) {
       game.size = file.size;
       game.can_launch = true;
 
-      // check got a metadata file
+      // check for a metadata file (fall back to handler's metadata)
       BlitGameMetadata meta;
       auto meta_filename = game.filename + ".blmeta";
       if(parse_file_metadata(meta_filename, meta))
@@ -503,6 +504,7 @@ void render(uint32_t time) {
   screen.pen = theme.color_background;
   screen.clear();
 
+  // display background swoosh if not displaying a screenshot or the credits
   if(currentScreen != Screen::screenshot && currentScreen != Screen::credits && selected_game.type != GameType::screenshot) {
     screen.pen = Pen(255, 255, 255);
     swoosh(time, 5100.0f, 3900.0f, 1900.0f, 900.0f, 3500);
@@ -512,10 +514,13 @@ void render(uint32_t time) {
     swoosh(time, 5100.0f, 3900.0f, 900.0f, 1100.0f, 5000);
   }
 
+  // display image preview
   if(!game_list.empty() && selected_game.type == GameType::screenshot && screenshot) {
     if(screenshot->bounds.w == screen.bounds.w) {
+      // full screen image
       screen.blit(screenshot, Rect(Point(0, 0), screenshot->bounds), Point(0, 0));
     } else if(screenshot->bounds == Size(128, 128)) {
+      // standard spritesheet size, show in info column
       screen.pen = Pen(0, 0, 0, 255);
       screen.rectangle(Rect(game_info_offset, Size(128, 128)));
       screen.blit(screenshot, Rect(Point(0, 0), screenshot->bounds), game_info_offset);
@@ -524,7 +529,7 @@ void render(uint32_t time) {
     }
 
     if(currentScreen == Screen::screenshot) {
-      // back
+      // displaying screenshot, show back action
       screen.sprite(5, Point(game_actions_offset.x, game_actions_offset.y + 12));
       screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R180);
       render_fps(us_start);
@@ -580,6 +585,8 @@ void render(uint32_t time) {
       y += ROW_HEIGHT;
     }
     screen.clip = Rect(Point(0, 0), screen.bounds);
+
+    // info / actions
 
     // delete
     screen.sprite(2, Point(game_actions_offset.x, game_actions_offset.y));
@@ -755,6 +762,7 @@ void update(uint32_t time) {
     delete_current_game();
   }
 
+  // launch game / show screenshot fullscreen
   if(!game_list.empty()) {
     if(button_a) {
       if(selected_game.type == GameType::screenshot && !selected_game.can_launch) {

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -26,7 +26,7 @@ struct PathSave {
 
 static const int path_save_slot = 256;
 
-Dialog dialog;
+static Dialog dialog;
 
 const Font launcher_font(font8x8);
 
@@ -34,41 +34,41 @@ constexpr uint32_t qspi_flash_sector_size = 64 * 1024;
 
 static Screen current_screen = Screen::main;
 
-bool show_fps = false;
-bool sd_detected = true;
-Vec2 file_list_scroll_offset(10.0f, 0.0f);
-Point game_info_offset(120, 20);
-Point game_actions_offset(game_info_offset.x + 128 + 8, 28);
-float directory_list_scroll_offset = 0.0f;
+static bool show_fps = false;
+static bool sd_detected = true;
+static Vec2 file_list_scroll_offset(10.0f, 0.0f);
+static Point game_info_offset(120, 20);
+static Point game_actions_offset(game_info_offset.x + 128 + 8, 28);
+static float directory_list_scroll_offset = 0.0f;
 
-std::vector<GameInfo> game_list;
-std::list<DirectoryInfo> directory_list;
-std::list<DirectoryInfo>::iterator current_directory;
+static std::vector<GameInfo> game_list;
+static std::list<DirectoryInfo> directory_list;
+static std::list<DirectoryInfo>::iterator current_directory;
 
-SortBy file_sort = SortBy::name;
+static SortBy file_sort = SortBy::name;
 
-GameInfo selected_game;
-BlitGameMetadata selected_game_metadata;
+static GameInfo selected_game;
+static BlitGameMetadata selected_game_metadata;
 
-Surface *spritesheet;
-Surface *screenshot;
+static Surface *spritesheet;
+static Surface *screenshot;
 
-AutoRepeat ar_button_up(250, 600);
-AutoRepeat ar_button_down(250, 600);
-AutoRepeat ar_button_left(0, 0);
-AutoRepeat ar_button_right(0, 0);
+static AutoRepeat ar_button_up(250, 600);
+static AutoRepeat ar_button_down(250, 600);
+static AutoRepeat ar_button_left(0, 0);
+static AutoRepeat ar_button_right(0, 0);
 
 #ifndef PICO_BUILD
-uint8_t screenshot_buf[320 * 240 * 3];
+static uint8_t screenshot_buf[320 * 240 * 3];
 #endif
 
-int calc_num_blocks(uint32_t size) {
+static int calc_num_blocks(uint32_t size) {
   return (size - 1) / qspi_flash_sector_size + 1;
 }
 
 // insertion sort
 template <class Iterator, class Compare>
-void insertion_sort(Iterator first, Iterator last, Compare comp) {
+static void insertion_sort(Iterator first, Iterator last, Compare comp) {
   if(last - first < 2)
     return;
 
@@ -82,7 +82,7 @@ void insertion_sort(Iterator first, Iterator last, Compare comp) {
   }
 }
 
-bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata, bool unpack_images = false) {
+static bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata, bool unpack_images = false) {
   blit::File f(filename);
 
   if(!f.is_open())
@@ -127,7 +127,7 @@ bool parse_file_metadata(const std::string &filename, BlitGameMetadata &metadata
   return false;
 }
 
-void sort_file_list() {
+static void sort_file_list() {
     using Iterator = std::vector<GameInfo>::iterator;
     using Compare = bool(const GameInfo &, const GameInfo &);
 
@@ -142,7 +142,7 @@ void sort_file_list() {
     }
 }
 
-void load_file_list(const std::string &directory) {
+static void load_file_list(const std::string &directory) {
 
   game_list.clear();
 
@@ -238,7 +238,7 @@ void load_file_list(const std::string &directory) {
   sort_file_list();
 }
 
-void load_directory_list(const std::string &directory) {
+static void load_directory_list(const std::string &directory) {
   directory_list.clear();
 
   auto dir_filter = [](const FileInfo &info){
@@ -269,7 +269,7 @@ void load_directory_list(const std::string &directory) {
   }
 }
 
-void load_current_game_metadata() {
+static void load_current_game_metadata() {
   bool loaded = false;
 
   if(!game_list.empty()) {
@@ -321,7 +321,7 @@ void load_current_game_metadata() {
   }
 }
 
-bool launch_current_game() {
+static bool launch_current_game() {
   // save last file launched
   PathSave save{};
   strncpy(save.last_path, selected_game.filename.c_str(), sizeof(save.last_path) - 1);
@@ -333,7 +333,7 @@ bool launch_current_game() {
   return api.launch(selected_game.filename.c_str());
 }
 
-void delete_current_game() {
+static void delete_current_game() {
   dialog.show("Confirm", "Really delete " + selected_game.title + "?", [](bool yes){
     if(yes) {
       if(selected_game.filename.compare(0, 7, "flash:/") == 0)
@@ -347,7 +347,7 @@ void delete_current_game() {
   });
 }
 
-void init_lists() {
+static void init_lists() {
   load_directory_list("/");
   current_directory = directory_list.begin();
 
@@ -356,7 +356,7 @@ void init_lists() {
   load_current_game_metadata();
 }
 
-void scan_flash() {
+static void scan_flash() {
 #ifdef TARGET_32BLIT_HW
   const uint32_t qspi_flash_sector_size = 64 * 1024;
   const uint32_t qspi_flash_size = 32768 * 1024;
@@ -444,7 +444,7 @@ void init() {
   credits::prepare();
 }
 
-void swoosh(uint32_t time, float t1, float t2, float s1, float s2, int t0, int offset_y=120, int size=60, int alpha=64) {
+static void swoosh(uint32_t time, float t1, float t2, float s1, float s2, int t0, int offset_y=120, int size=60, int alpha=64) {
   constexpr int swoosh_resolution = 32;
   int w = (screen.bounds.w + swoosh_resolution - 1) / swoosh_resolution;
 
@@ -474,7 +474,7 @@ void swoosh(uint32_t time, float t1, float t2, float s1, float s2, int t0, int o
   }
 }
 
-void render_fps(uint32_t us_start) {
+static void render_fps(uint32_t us_start) {
   if(!show_fps) return;
   // draw FPS meter
   uint32_t us_end = now_us();

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -230,7 +230,7 @@ void load_file_list(const std::string &directory) {
 
   int total_items = (int)game_list.size();
   if(selected_menu_item >= total_items)
-    selected_menu_item = total_items - 1;
+    selected_menu_item = std::max(0, total_items - 1);
 
   // probably doesn't do anything...
   game_list.shrink_to_fit();

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -503,6 +503,14 @@ static void render_directory_list() {
     return;
 
   int width = screen.bounds.w - game_info_offset.x - 10;
+
+  // darken behind if showing screenshot
+  if(screenshot) {
+    screen.pen = theme.color_background;
+    screen.pen.a = 150;
+    screen.rectangle(Rect(game_info_offset.x - 10, 0, width + 20, 20));
+  }
+
   screen.clip = Rect(game_info_offset.x, 5, width, text_align_height);
 
   for(auto &directory : directory_list) {
@@ -526,7 +534,13 @@ static void render_file_list() {
     return;
 
   // background
-  screen.pen = theme.color_overlay;
+  if(screenshot) {
+    // darken if showing screenshot
+    screen.pen = theme.color_background;
+    screen.pen.a = 150;
+  } else
+    screen.pen = theme.color_overlay;
+
   screen.rectangle(Rect(0, 0, game_info_offset.x - 10, screen.bounds.h));
 
   screen.clip = Rect(0, 0, game_info_offset.x - 20, screen.bounds.h);
@@ -609,26 +623,14 @@ void render(uint32_t time) {
   }
 
   // display image preview
-  if(!game_list.empty() && selected_game.type == GameType::screenshot && screenshot) {
+  if(!game_list.empty() && screenshot)
     render_screenshot();
 
-    if(current_screen == Screen::screenshot) {
-      // displaying screenshot, show back action
-      screen.sprite(5, Point(game_actions_offset.x, game_actions_offset.y + 12));
-      screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R180);
-      render_fps(us_start);
-      return;
-    }
-
-    // Darken behind the file/directory menus so they're visible
-    screen.pen = theme.color_background;
-    screen.pen.a = 150;
-    screen.rectangle(Rect(game_info_offset.x - 10, 0, screen.bounds.w - game_info_offset.x + 10, 20));
-    screen.rectangle(Rect(0, 0, game_info_offset.x - 10, screen.bounds.h));
+  // don't display lists over fullscreen screenshot
+  if(current_screen != Screen::screenshot) {
+    render_directory_list();
+    render_file_list();
   }
-
-  render_directory_list();
-  render_file_list();
 
   // current file info/actions
   if(!game_list.empty()) {
@@ -643,6 +645,10 @@ void render(uint32_t time) {
           screen.sprite(1, Point(game_actions_offset.x, game_actions_offset.y + 12));
           screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R90);
         }
+      } else if (current_screen == Screen::screenshot) {
+        // exit fullscreen
+        screen.sprite(5, Point(game_actions_offset.x, game_actions_offset.y + 12));
+        screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R180);
       } else {
         // view screenshot fullscreen
         screen.sprite(4, Point(game_actions_offset.x, game_actions_offset.y + 12));

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -270,7 +270,6 @@ void load_directory_list(const std::string &directory) {
 }
 
 void load_current_game_metadata() {
-  static std::string current_screenshot = "";
   bool loaded = false;
 
   if(!game_list.empty()) {
@@ -297,16 +296,14 @@ void load_current_game_metadata() {
 
 #ifndef PICO_BUILD
   if(selected_game.type == GameType::screenshot) {
-    if(selected_game.filename != current_screenshot) {
-      // Free any old buffers
-      if(screenshot) {
-        delete[] screenshot->palette;
-        delete screenshot;
-        screenshot = nullptr;
-      }
-      // Load the new screenshot
-      screenshot = Surface::load(selected_game.filename, screenshot_buf, sizeof(screenshot_buf));
+    // Free any old buffers
+    if(screenshot) {
+      delete[] screenshot->palette;
+      delete screenshot;
+      screenshot = nullptr;
     }
+    // Load the new screenshot
+    screenshot = Surface::load(selected_game.filename, screenshot_buf, sizeof(screenshot_buf));
   } else {
     // Not showing a screenshot, free the buffers
     if(screenshot) {

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -204,7 +204,6 @@ void load_file_list(const std::string &directory) {
       c = tolower(c);
 
     if(ext == "blit") {
-
       GameInfo game;
       game.type = GameType::game;
       game.title = file.name.substr(0, file.name.length() - 5);
@@ -466,11 +465,9 @@ void swoosh(uint32_t time, float t1, float t2, float s1, float s2, int t0, int o
     int range = y2 - y1;
 
     for(auto y = 0; y <= range; y++) {
-      if(y > range / 2){
+      if(y > range / 2) {
         screen.pen.a = alpha - (alpha * y / range);
-      }
-      else
-      {
+      } else {
         screen.pen.a = alpha * y / range;
       }
       // This is an optimisation, not an aesthetic choice!
@@ -595,9 +592,7 @@ void render(uint32_t time) {
           screen.sprite(1, Point(game_actions_offset.x, game_actions_offset.y + 12));
           screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R90);
         }
-      }
-      else
-      {
+      } else {
         // view screenshot fullscreen
         screen.sprite(4, Point(game_actions_offset.x, game_actions_offset.y + 12));
         screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R90);
@@ -631,8 +626,7 @@ void render(uint32_t time) {
       snprintf(buf, 20, "%i block%s", num_blocks, num_blocks == 1 ? "" : "s");
       screen.text(buf, minimal_font, Point(game_info_offset.x, screen.bounds.h - 16));
     }
-  }
-  else {
+  } else {
     screen.pen = theme.color_text;
 
     if(/*current_directory->name != "FLASH" &&*/ !blit::is_storage_available())
@@ -693,16 +687,14 @@ void update(uint32_t time) {
 
   auto old_menu_item = selected_menu_item;
 
-  if(button_up)
-  {
+  if(button_up) {
     selected_menu_item--;
     if(selected_menu_item < 0) {
       selected_menu_item = total_items - 1;
     }
   }
 
-  if(button_down)
-  {
+  if(button_down) {
     selected_menu_item++;
     if(selected_menu_item > total_items - 1) {
       selected_menu_item = 0;
@@ -764,12 +756,10 @@ void update(uint32_t time) {
   }
 
   if(!game_list.empty()) {
-    if(button_a)
-    {
+    if(button_a) {
       if(selected_game.type == GameType::screenshot && !selected_game.can_launch) {
         currentScreen = Screen::screenshot;
-      }
-      else {
+      } else {
         if(!launch_current_game())
           dialog.show("Error!", "Failed to launch " + selected_game.filename, [](bool){}, false);
       }

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -671,6 +671,7 @@ void update(uint32_t time) {
   if(dialog.update())
     return;
 
+  // update/close credits
   if (current_screen == Screen::credits) {
     credits::update(time);
 
@@ -685,11 +686,13 @@ void update(uint32_t time) {
     return;
   }
 
+  // display credits
   if (button_menu) {
     credits::reset_scrolling();
     current_screen = Screen::credits;
   }
 
+  // scroll through file list
   int total_items = (int)game_list.size();
 
   auto old_menu_item = selected_menu_item;
@@ -714,7 +717,7 @@ void update(uint32_t time) {
       current_screen = Screen::main;
     }
   } else {
-    // switch between flash and SD lists
+    // scroll through directories
     if(button_left) {
       if(current_directory == directory_list.begin())
         current_directory = --directory_list.end();
@@ -729,6 +732,7 @@ void update(uint32_t time) {
       }
     }
 
+    // reload file list if dir changed
     if(button_left || button_right) {
       load_file_list(current_directory->name);
 
@@ -736,6 +740,7 @@ void update(uint32_t time) {
       old_menu_item = -1;
     }
 
+    // toggle sort mode
     if (button_y) {
       file_sort = file_sort == SortBy::name ? SortBy::size : SortBy::name;
       sort_file_list();
@@ -746,6 +751,9 @@ void update(uint32_t time) {
   file_list_scroll_offset.y += ((selected_menu_item * ROW_HEIGHT) - file_list_scroll_offset.y) / 5.0f;
 
   directory_list_scroll_offset += (current_directory->x + current_directory->w / 2 - directory_list_scroll_offset) / 5.0f;
+
+  if(game_list.empty())
+    return;
 
   // load metadata for selected item
   if(selected_menu_item != old_menu_item) {
@@ -758,19 +766,17 @@ void update(uint32_t time) {
   }
 
   // delete current game / screenshot
-  if (button_x && !game_list.empty()) {
+  if(button_x) {
     delete_current_game();
   }
 
   // launch game / show screenshot fullscreen
-  if(!game_list.empty()) {
-    if(button_a) {
-      if(selected_game.type == GameType::screenshot && !selected_game.can_launch) {
-        current_screen = Screen::screenshot;
-      } else {
-        if(!launch_current_game())
-          dialog.show("Error!", "Failed to launch " + selected_game.filename, [](bool){}, false);
-      }
+  if(button_a) {
+    if(selected_game.type == GameType::screenshot && !selected_game.can_launch) {
+      current_screen = Screen::screenshot;
+    } else {
+      if(!launch_current_game())
+        dialog.show("Error!", "Failed to launch " + selected_game.filename, [](bool){}, false);
     }
   }
 }

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -32,7 +32,7 @@ const Font launcher_font(font8x8);
 
 constexpr uint32_t qspi_flash_sector_size = 64 * 1024;
 
-static Screen currentScreen = Screen::main;
+static Screen current_screen = Screen::main;
 
 bool show_fps = false;
 bool sd_detected = true;
@@ -505,7 +505,7 @@ void render(uint32_t time) {
   screen.clear();
 
   // display background swoosh if not displaying a screenshot or the credits
-  if(currentScreen != Screen::screenshot && currentScreen != Screen::credits && selected_game.type != GameType::screenshot) {
+  if(current_screen != Screen::screenshot && current_screen != Screen::credits && selected_game.type != GameType::screenshot) {
     screen.pen = Pen(255, 255, 255);
     swoosh(time, 5100.0f, 3900.0f, 1900.0f, 900.0f, 3500);
     screen.pen = theme.color_accent;
@@ -528,7 +528,7 @@ void render(uint32_t time) {
       screen.stretch_blit(screenshot, Rect(Point(0, 0), screenshot->bounds), Rect(Point(0, 0), screen.bounds));
     }
 
-    if(currentScreen == Screen::screenshot) {
+    if(current_screen == Screen::screenshot) {
       // displaying screenshot, show back action
       screen.sprite(5, Point(game_actions_offset.x, game_actions_offset.y + 12));
       screen.sprite(0, Point(game_actions_offset.x + 10, game_actions_offset.y + 12), SpriteTransform::R180);
@@ -642,7 +642,7 @@ void render(uint32_t time) {
       screen.text("No Games Found.", launcher_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);
   }
 
-  if (currentScreen == Screen::credits) {
+  if (current_screen == Screen::credits) {
     credits::render();
   }
 
@@ -668,11 +668,11 @@ void update(uint32_t time) {
   bool button_left = ar_button_left.next(time, buttons.state & Button::DPAD_LEFT || joystick.x < -0.5f);
   bool button_right = ar_button_right.next(time, buttons.state & Button::DPAD_RIGHT || joystick.x > 0.5f);
 
-  if (currentScreen == Screen::credits) {
+  if (current_screen == Screen::credits) {
     credits::update(time);
 
     if (button_menu) {
-      currentScreen = Screen::main;
+      current_screen = Screen::main;
     }
 
     if(button_y) {
@@ -684,7 +684,7 @@ void update(uint32_t time) {
 
   if (button_menu) {
     credits::reset_scrolling();
-    currentScreen = Screen::credits;
+    current_screen = Screen::credits;
   }
 
   if(dialog.update())
@@ -708,10 +708,10 @@ void update(uint32_t time) {
     }
   }
 
-  if(currentScreen == Screen::screenshot) {
+  if(current_screen == Screen::screenshot) {
     // b to exit full screen screenshot view
     if(button_b) {
-      currentScreen = Screen::main;
+      current_screen = Screen::main;
     }
   } else {
     // switch between flash and SD lists
@@ -753,8 +753,8 @@ void update(uint32_t time) {
   }
 
   // paranoid bail out if you're browsing screenshots full screen and come across a game
-  if(selected_game.type != GameType::screenshot && currentScreen == Screen::screenshot) {
-    currentScreen = Screen::main;
+  if(selected_game.type != GameType::screenshot && current_screen == Screen::screenshot) {
+    current_screen = Screen::main;
   }
 
   // delete current game / screenshot
@@ -766,7 +766,7 @@ void update(uint32_t time) {
   if(!game_list.empty()) {
     if(button_a) {
       if(selected_game.type == GameType::screenshot && !selected_game.can_launch) {
-        currentScreen = Screen::screenshot;
+        current_screen = Screen::screenshot;
       } else {
         if(!launch_current_game())
           dialog.show("Error!", "Failed to launch " + selected_game.filename, [](bool){}, false);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -537,7 +537,8 @@ void render(uint32_t time) {
 
   // list folders
   if(!directory_list.empty()) {
-    screen.clip = Rect(120, 5, 190, text_align_height);
+    int width = screen.bounds.w - game_info_offset.x - 10;
+    screen.clip = Rect(game_info_offset.x, 5, width, text_align_height);
 
     for(auto &directory : directory_list) {
       if(directory.name == current_directory->name)
@@ -545,14 +546,14 @@ void render(uint32_t time) {
       else
         screen.pen = theme.color_text;
 
-      int x = 120 + 95 + directory.x - directory_list_scroll_offset;
+      int x = 120 + (width / 2) + directory.x - directory_list_scroll_offset;
       screen.text(directory.name == "/" ? "ROOT" : directory.name, launcher_font, Rect(x, 5, 190, text_align_height), true, TextAlign::center_v);
     }
 
     screen.clip = Rect(Point(0, 0), screen.bounds);
   }
 
-  int y = 115 - file_list_scroll_offset.y;
+  int y = (screen.bounds.h / 2) - 5 - file_list_scroll_offset.y;
   int i = 0;
 
   // list games
@@ -561,13 +562,15 @@ void render(uint32_t time) {
     screen.rectangle(Rect(0, 0, game_info_offset.x - 10, screen.bounds.h));
 
     screen.clip = Rect(0, 0, game_info_offset.x - 20, screen.bounds.h);
+    int title_w = screen.clip.w - file_list_scroll_offset.x;
+
     for(auto &file : game_list) {
       if(i++ == selected_menu_item)
         screen.pen = theme.color_accent;
       else
         screen.pen = theme.color_text;
 
-      screen.text(file.title, launcher_font, Rect(file_list_scroll_offset.x, y, 90, text_align_height), true, TextAlign::center_v);
+      screen.text(file.title, launcher_font, Rect(file_list_scroll_offset.x, y, title_w, text_align_height), true, TextAlign::center_v);
       y += ROW_HEIGHT;
     }
     screen.clip = Rect(Point(0, 0), screen.bounds);

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -442,7 +442,9 @@ void init() {
 
 void swoosh(uint32_t time, float t1, float t2, float s1, float s2, int t0, int offset_y=120, int size=60, int alpha=64) {
   constexpr int swoosh_resolution = 32;
-  for(auto x = 0; x < screen.bounds.w / swoosh_resolution; x++) {
+  int w = (screen.bounds.w + swoosh_resolution - 1) / swoosh_resolution;
+
+  for(auto x = 0; x < w; x++) {
     float t_a = (x / s1) + float(time + t0) / t1;
     float t_b = (x / s2) + float(time + t0) / t2;
 

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -636,7 +636,7 @@ void render(uint32_t time) {
   } else {
     screen.pen = theme.color_text;
 
-    if(/*current_directory->name != "FLASH" &&*/ !blit::is_storage_available())
+    if(current_directory->name != "flash:" && !blit::is_storage_available())
       screen.text("No SD Card\nDetected.", launcher_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);
     else
       screen.text("No Games Found.", launcher_font, Point(screen.bounds.w / 2, screen.bounds.h / 2), true, TextAlign::center_center);


### PR DESCRIPTION
Started off trying to run the launcher on pico things. Then got lost in the launcher code so this happened.

A few of these are bug fixes (most importantly 2b84bd209982ba90e5b853ff28c34e2c4b2bc743). First four are entirely for squishing the launcher onto a picosystem.

Now I need to make `scan_flash` go away... (Shouldn't be too hard, firmware already has a list of where things are for other reasons)