### PR TITLE
Sync some blit_metadata changes to 32blit-pico

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -157,7 +157,14 @@ function(blit_metadata TARGET FILE)
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${FILE})
 
     # get the inputs/outputs for the asset tool (at configure time)
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
+    execute_process(
+        COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+        RESULT_VARIABLE TOOL_RESULT
+    )
+    if(${TOOL_RESULT})
+        message(FATAL_ERROR "Reading metadata config failed!\n")
+    endif()
+
     include(${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
 
     # create metadata/binary info source at build time

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -149,11 +149,15 @@ function(blit_executable NAME SOURCES)
 endfunction()
 
 function(blit_metadata TARGET FILE)
+    if(NOT IS_ABSOLUTE ${FILE})
+        set(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+    endif()
+
     # cause cmake to reconfigure whenever the asset list changes
-    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${FILE})
 
     # get the inputs/outputs for the asset tool (at configure time)
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
     include(${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake)
 
     # create metadata/binary info source at build time
@@ -161,8 +165,8 @@ function(blit_metadata TARGET FILE)
 
     add_custom_command(
         OUTPUT ${METADATA_SOURCE}
-        COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --pico-bi ${METADATA_SOURCE}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
+        COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --force --config ${FILE} --pico-bi ${METADATA_SOURCE}
+        DEPENDS ${FILE}
     )
 
     # add the generated source

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -131,6 +131,7 @@ function(blit_executable_common NAME)
 endfunction()
 
 function(blit_executable_int_flash NAME SOURCES)
+    message(STATUS "Processing ${NAME}")
     add_executable(${NAME} ${SOURCES} ${ARGN})
     target_link_libraries(${NAME} BlitHalPico BlitEngine)
 


### PR DESCRIPTION
Port two commits that were missed in the pico port. This does highlight that the first half of `blit_metadata` is identical between the three copies of it...