### PR TITLE
Firmware: reject erase commands beyond the end of external flash

### DIFF
--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -510,6 +510,10 @@ static void erase_flash_game(uint32_t offset) {
   if(offset & (qspi_flash_sector_size - 1))
     return;
 
+  // reject beyond end of flash
+  if(offset >= qspi_flash_size)
+    return;
+
   // attempt to get size, falling back to a single sector
   int erase_size = 1;
   for(auto &game : game_list) {


### PR DESCRIPTION
This prevents a crash when QSPI tries to read past the end of flash as a result of a bad serial command. 

There's also a patch waiting for the tools to stop it from doing that.