### PR TITLE
stm32: "fix" the Reset_Handler warning

### DIFF
--- a/32blit-stm32/startup_user.s
+++ b/32blit-stm32/startup_user.s
@@ -54,6 +54,8 @@
   .section  .text.do_init
   .weak  do_init
   .type  do_init, %function
+  .global Reset_Handler
+Reset_Handler: // avoid warning about this not existing
 do_init:
   push {r4, lr}
   mov r4, r0


### PR DESCRIPTION
Point it to `do_init` (the closest thing to a game's entry point)