### PR TITLE
blit_executable(_int_flash) improvements

### DIFF
--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -61,11 +61,18 @@ if (NOT DEFINED BLIT_ONCE)
 	# common helpers
 	function(blit_executable_args)
 		set(SOURCES)
+		set(INTERNAL_FLASH FALSE)
+
 		foreach(arg IN LISTS ARGN)
-			list(APPEND SOURCES ${arg})
+			if(arg STREQUAL "INTERNAL_FLASH")
+				set(${arg} TRUE)
+			else()
+				list(APPEND SOURCES ${arg})
+			endif()
 		endforeach()
 
 		set(SOURCES ${SOURCES} PARENT_SCOPE)
+		set(INTERNAL_FLASH ${INTERNAL_FLASH} PARENT_SCOPE)
 	endfunction()
 
 	if (32BLIT_HW)

--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -61,7 +61,12 @@ if (NOT DEFINED BLIT_ONCE)
 	# common helpers
 	function(blit_executable_args)
 		set(SOURCES)
-		set(INTERNAL_FLASH FALSE)
+
+		if(DEFINED BLIT_EXECUTABLE_INTERNAL_FLASH)
+			set(INTERNAL_FLASH ${BLIT_EXECUTABLE_INTERNAL_FLASH})
+		else()
+			set(INTERNAL_FLASH FALSE)
+		endif()
 
 		foreach(arg IN LISTS ARGN)
 			if(arg STREQUAL "INTERNAL_FLASH")

--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -58,6 +58,16 @@ if (NOT DEFINED BLIT_ONCE)
 		target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 	endfunction()
 
+	# common helpers
+	function(blit_executable_args)
+		set(SOURCES)
+		foreach(arg IN LISTS ARGN)
+			list(APPEND SOURCES ${arg})
+		endforeach()
+
+		set(SOURCES ${SOURCES} PARENT_SCOPE)
+	endfunction()
+
 	if (32BLIT_HW)
 		set(FLASH_PORT "AUTO" CACHE STRING "Port to use for flash")
 

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -138,7 +138,7 @@ function(blit_executable_common NAME)
 
 endfunction()
 
-function(blit_executable_int_flash NAME)
+function(blit_executable NAME)
     message(STATUS "Processing ${NAME}")
     blit_executable_args(${ARGN})
 
@@ -154,10 +154,6 @@ function(blit_executable_int_flash NAME)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.uf2
         DESTINATION bin
     )
-endfunction()
-
-function(blit_executable NAME SOURCES)
-    blit_executable_int_flash(${NAME} ${SOURCES} ${ARGN})
 endfunction()
 
 function(blit_metadata TARGET FILE)

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -138,9 +138,11 @@ function(blit_executable_common NAME)
 
 endfunction()
 
-function(blit_executable_int_flash NAME SOURCES)
+function(blit_executable_int_flash NAME)
     message(STATUS "Processing ${NAME}")
-    add_executable(${NAME} ${SOURCES} ${ARGN})
+    blit_executable_args(${ARGN})
+
+    add_executable(${NAME} ${SOURCES})
     target_link_libraries(${NAME} BlitHalPico BlitEngine)
     target_link_options(${NAME} PUBLIC -specs=nano.specs -u _printf_float)
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -144,12 +144,14 @@ if(DEFINED VIDEO_CAPTURE AND VIDEO_CAPTURE)
 	)
 endif()
 
-function(blit_executable NAME SOURCES)
+function(blit_executable NAME)
 	message(STATUS "Processing ${NAME}")
+	blit_executable_args(${ARGN})
+
 	if(ANDROID)
-		add_library(${NAME} SHARED ${SOURCES} ${ARGN})
+		add_library(${NAME} SHARED ${SOURCES})
 	else()
-		add_executable(${NAME} MACOSX_BUNDLE ${SOURCES} ${ARGN})
+		add_executable(${NAME} MACOSX_BUNDLE ${SOURCES})
 	endif()
 
 	install(TARGETS ${NAME}
@@ -172,7 +174,7 @@ function(blit_executable NAME SOURCES)
     		COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			"${DLL}"
 			$<TARGET_FILE_DIR:${NAME}>
-		)  
+		)
 	endforeach()
 
 	if(EMSCRIPTEN)

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -211,10 +211,6 @@ function(blit_executable NAME)
 	endif()
 endfunction()
 
-function(blit_executable_int_flash NAME SOURCES)
-	blit_executable(${NAME} ${SOURCES} ${ARGN})
-endfunction()
-
 function(blit_metadata TARGET FILE)
 	if(NOT EXISTS ${FILE})
 		set(FILE ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND SOURCES
+add_library(BlitHalSTM32 OBJECT
 	startup_stm32h750xx.s
 	Src/main.c
 	Src/stm32h7xx_it.c
@@ -118,8 +118,6 @@ set_source_files_properties(
 
 	PROPERTIES LANGUAGE CXX
 )
-
-add_library(BlitHalSTM32 OBJECT ${SOURCES})
 
 set(INCLUDE_DIRS
 	${CMAKE_CURRENT_SOURCE_DIR}/Inc

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -16,6 +16,11 @@ function(blit_executable NAME)
 	message(STATUS "Processing ${NAME}")
 	blit_executable_args(${ARGN})
 
+	if(INTERNAL_FLASH)
+		blit_executable_int_flash(${NAME} ${SOURCES})
+		return()
+	endif()
+
 	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
 	add_executable(${NAME} ${USER_STARTUP} ${SOURCES})
 

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -12,10 +12,12 @@ function(blit_executable_common NAME)
 	)
 endfunction()
 
-function(blit_executable NAME SOURCES)
+function(blit_executable NAME)
 	message(STATUS "Processing ${NAME}")
+	blit_executable_args(${ARGN})
+
 	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
-	add_executable(${NAME} ${USER_STARTUP} ${SOURCES} ${ARGN})
+	add_executable(${NAME} ${USER_STARTUP} ${SOURCES})
 
 	# Ideally we want the .blit filename to match the .elf, but TARGET_FILE_BASE_NAME isn't always available
 	# (This only affects the firmware updater as it's the only thing setting a custom OUTPUT_NAME)

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -1,4 +1,5 @@
 set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}")
+set(HAL_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 set(USER_STARTUP ${CMAKE_CURRENT_LIST_DIR}/startup_user.s ${CMAKE_CURRENT_LIST_DIR}/startup_user.cpp)
 
@@ -17,6 +18,11 @@ function(blit_executable NAME)
 	blit_executable_args(${ARGN})
 
 	if(INTERNAL_FLASH)
+		# make sure the HAL is built (external projects)
+		if(NOT TARGET BlitHalSTM32)
+			add_subdirectory(${HAL_DIR} 32blit-stm32)
+		endif()
+
 		blit_executable_int_flash(${NAME} ${SOURCES})
 		return()
 	endif()

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 project (firmware)
 find_package (32BLIT CONFIG REQUIRED PATHS ..)
 
-blit_executable_int_flash(firmware firmware.cpp)
+blit_executable(firmware INTERNAL_FLASH firmware.cpp)
 target_link_libraries(firmware LauncherShared)
 
 target_compile_definitions(firmware


### PR DESCRIPTION
Basically this replaces `blit_executable_int_flash(name crc.cpp)` with `blit_executable(name INTERNAL_FLASH src.cpp)` but also:

- makes it work for external projects
- allows overriding the default with `-DBLIT_EXECUTABLE_INTERNAL_FLASH=`
- removes the sdl/pico stubs

(Somewhat inspired by `add_executable(WIN32/MACOSX_BUNDLE)` ... and needing a similar thing for pico standalone/loader builds)