### PR TITLE
include cstdint in point.hpp

### DIFF
--- a/32blit/types/point.hpp
+++ b/32blit/types/point.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "mat3.hpp"
 #include "vec2.hpp"
 


### PR DESCRIPTION
For `int32_t`. rect/size.hpp already do this.