### PR TITLE
Extend .blit header with api/device info

### DIFF
--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -1,7 +1,7 @@
 set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}")
 set(HAL_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-set(USER_STARTUP ${CMAKE_CURRENT_LIST_DIR}/startup_user.s ${CMAKE_CURRENT_LIST_DIR}/startup_user.cpp)
+set(USER_STARTUP ${CMAKE_CURRENT_LIST_DIR}/startup_user.S ${CMAKE_CURRENT_LIST_DIR}/startup_user.cpp)
 
 function(blit_executable_common NAME)
 	target_link_libraries(${NAME} BlitEngine)

--- a/32blit-stm32/startup_user.S
+++ b/32blit-stm32/startup_user.S
@@ -25,6 +25,8 @@
   ******************************************************************************
 */
 
+#include "engine/api_version.h"
+
   .syntax unified
   .cpu cortex-m7
   .fpu softvfp
@@ -132,7 +134,9 @@ g_pfnVectors:
   .word  _ZN4blit4tickEm
   .word  do_init
   .word _flash_end
-  .word flash_start // temp
+  .word 1 // device_id = 1 + padding
+  .hword BLIT_API_VERSION_MAJOR
+  .hword BLIT_API_VERSION_MINOR
 
 /*
 .weak      render

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "api_version.h"
 #include "engine.hpp"
 #include "file.hpp"
 #include "../audio/audio.hpp"
@@ -17,7 +18,7 @@ namespace blit {
 
   using AllocateCallback = uint8_t *(*)(size_t);
 
-  constexpr uint16_t api_version_major = 0, api_version_minor = 2;
+  constexpr uint16_t api_version_major = BLIT_API_VERSION_MAJOR, api_version_minor = BLIT_API_VERSION_MINOR;
 
   // template for screen modes
   struct SurfaceTemplate {

--- a/32blit/engine/api_version.h
+++ b/32blit/engine/api_version.h
@@ -1,0 +1,3 @@
+#pragma once
+#define BLIT_API_VERSION_MAJOR 0
+#define BLIT_API_VERSION_MINOR 2

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -125,7 +125,7 @@ static bool parse_file_header(FIL &fh, BlitGameHeader &header, uint32_t &header_
   // read header
   f_read(&fh, &header, sizeof(header), &bytes_read);
 
-  if(header.magic != blit_game_magic)
+  if(header.magic != blit_game_magic || (header.device_id != BlitDevice::STM32H7_32BlitOld && header.device_id != BlitDevice::STM32H7_32Blit))
     return false;
 
   return true;
@@ -196,7 +196,7 @@ static bool read_flash_game_header(uint32_t offset, BlitGameHeader &header) {
   if(qspi_read_buffer(offset, reinterpret_cast<uint8_t *>(&header), sizeof(header)) != QSPI_OK)
     return false;
 
-  if(header.magic != blit_game_magic)
+  if(header.magic != blit_game_magic || (header.device_id != BlitDevice::STM32H7_32BlitOld && header.device_id != BlitDevice::STM32H7_32Blit))
     return false;
 
   // make sure end/size is sensible

--- a/launcher-shared/executable.hpp
+++ b/launcher-shared/executable.hpp
@@ -13,6 +13,12 @@ using BlitTickFunction = uint32_t;
 using BlitInitFunction = uint32_t;
 #endif
 
+enum class BlitDevice : uint8_t {
+  STM32H7_32BlitOld = 0, // 32blit hw, old header
+  STM32H7_32Blit = 1, // 32blit hw
+  RP2040 = 2, // any RP2040-based device
+};
+
 // should match the layout in startup_user.s
 struct BlitGameHeader {
   uint32_t magic;
@@ -22,7 +28,13 @@ struct BlitGameHeader {
   BlitInitFunction init;
 
   uint32_t end;
-  uint32_t start;
+
+  BlitDevice device_id;
+  uint8_t unused[3];
+
+  // if device_id != 0
+  uint16_t api_version_major;
+  uint16_t api_version_minor;
 };
 
 // missing the "BLITMETA" header and size


### PR DESCRIPTION
Some patches from the pico launcher/api stuff. Adds a device id and the api version to the .blit file header, taking advantage of there being an unused constant `00 00 00 90` at the end for backwards compatibility (first byte is repurposed as device id, non-0 means the api info is there).

I have no idea where the name "STM32Blit" came from though. Should probably be something like STH32H7 (existing .blits are built for cortex-m7 and assume STM32 RAM layout, though there isn't a loader for anything that isn't a 32blit...)