### PR TITLE
sdl: set SDL_WINDOW_ALLOW_HIDPI

### DIFF
--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char *argv[]) {
 		metadata_title,
 		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 		System::width*2, System::height*2,
-		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
+		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
 	);
 
 	if (window == nullptr) {


### PR DESCRIPTION
Everything is already automatically scaled by the renderer. Makes things less blurry on hidpi setups. Tested on macOS and with `SDL_VIDEODRIVER=wayland`