### PR TITLE
Search for the 32blit executable if the module fails

### DIFF
--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -10,6 +10,17 @@ if (NOT DEFINED BLIT_ONCE)
 	# make sure that the tools are installed
 	execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit version RESULT_VARIABLE VERSION_STATUS OUTPUT_VARIABLE TOOLS_VERSION ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+	if(${VERSION_STATUS})
+		# check for the executable if the module isn't found
+		find_program(32BLIT_TOOLS_EXECUTABLE 32blit)
+		if(32BLIT_TOOLS_EXECUTABLE)
+			# get the version
+			execute_process(COMMAND ${32BLIT_TOOLS_EXECUTABLE} version RESULT_VARIABLE VERSION_STATUS OUTPUT_VARIABLE TOOLS_VERSION ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+		endif()
+	else()
+		set(32BLIT_TOOLS_EXECUTABLE ${PYTHON_EXECUTABLE} -m ttblit)
+	endif()
+
 	# get just the python command to output to the user
 	get_filename_component(PYTHON_USER_EXECUTABLE "${PYTHON_EXECUTABLE}" NAME)
 
@@ -37,7 +48,7 @@ if (NOT DEFINED BLIT_ONCE)
 
 		# get the inputs/outputs for the asset tool (at configure time)
 		execute_process(
-		    COMMAND ${PYTHON_EXECUTABLE} -m ttblit --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake
+		    COMMAND ${32BLIT_TOOLS_EXECUTABLE} --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake
             RESULT_VARIABLE TOOL_RESULT
 		)
 		if(${TOOL_RESULT})
@@ -49,7 +60,7 @@ if (NOT DEFINED BLIT_ONCE)
 		# do asset packing (at build time)
 		add_custom_command(
 			OUTPUT ${ASSET_OUTPUTS}
-			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit --debug  pack --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR}
+			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} --debug  pack --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR}
 			DEPENDS ${ASSET_DEPENDS} ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
 		)
 

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -179,7 +179,7 @@ function(blit_metadata TARGET FILE)
 
     # get the inputs/outputs for the asset tool (at configure time)
     execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+        COMMAND ${32BLIT_TOOLS_EXECUTABLE} cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
         RESULT_VARIABLE TOOL_RESULT
     )
     if(${TOOL_RESULT})
@@ -193,7 +193,7 @@ function(blit_metadata TARGET FILE)
 
     add_custom_command(
         OUTPUT ${METADATA_SOURCE}
-        COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --force --config ${FILE} --pico-bi ${METADATA_SOURCE}
+        COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --force --config ${FILE} --pico-bi ${METADATA_SOURCE}
         DEPENDS ${FILE}
     )
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -221,7 +221,7 @@ function(blit_metadata TARGET FILE)
 
 	# parse the metadata to variables
 	execute_process(
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
 		RESULT_VARIABLE TOOL_RESULT
 	)
 	if(${TOOL_RESULT})
@@ -244,7 +244,7 @@ function(blit_metadata TARGET FILE)
 
 		add_custom_command(
 			OUTPUT ${ICON}
-			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --force --config ${FILE} --icns ${ICON}
+			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --force --config ${FILE} --icns ${ICON}
 			DEPENDS ${METADATA_DEPENDS} ${FILE}
 		)
 

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -186,6 +186,6 @@ function(blit_executable_int_flash NAME SOURCES)
 
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.dfu"
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit dfu build --force --output-file ${NAME}.dfu --input-file ${NAME}.bin
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} dfu build --force --output-file ${NAME}.dfu --input-file ${NAME}.bin
 	)
 endfunction()

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -52,10 +52,10 @@ function(blit_executable NAME)
 
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.blit"
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit relocs --elf-file $<TARGET_FILE:${NAME}> --bin-file ${NAME}.bin --output ${BLIT_FILENAME}
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} relocs --elf-file $<TARGET_FILE:${NAME}> --bin-file ${NAME}.bin --output ${BLIT_FILENAME}
 	)
 
-	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${PYTHON_EXECUTABLE} -m ttblit install --port=${FLASH_PORT} --launch ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
+	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOLS_EXECUTABLE} install --port=${FLASH_PORT} --launch ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
 endfunction()
 
 function(blit_metadata TARGET FILE)
@@ -68,7 +68,7 @@ function(blit_metadata TARGET FILE)
 
 	# get the inputs/outputs for the asset tool (at configure time)
 	execute_process(
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
 		RESULT_VARIABLE TOOL_RESULT
 	)
 	if(${TOOL_RESULT})
@@ -85,7 +85,7 @@ function(blit_metadata TARGET FILE)
 
 	add_custom_command(
 		TARGET ${TARGET} POST_BUILD
-		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
 	)
 
 	# force relink on change so that the post-build commands are rerun

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -1,6 +1,6 @@
 # embed the built firmware
 add_custom_command(
-    COMMAND ${PYTHON_EXECUTABLE} -m ttblit raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
+    COMMAND ${32BLIT_TOOLS_EXECUTABLE} raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
     OUTPUT firmware.hpp
     DEPENDS firmware
 )


### PR DESCRIPTION
Recently, trying to `pip install 32blit` results in:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
(or replace Debian/apt with Arch/pacman, or whatever else you're using...)

Okay, there aren't any 32blit-tools packages so let's try `pipx install 32blit`:

```
  installed package 32blit 0.7.3, installed using Python 3.11.3
  These apps are now globally available
    - 32blit
done! ✨ 🌟 ✨
```

Now I can run `32blit` and do things... except build, as that uses `python3 -m ttblit` which isn't found because I'm not running VS code in the venv (unless I set `PYTHON_EXECUTABLE` to point to the right thing)


So this PR is fixing that with a `find_program` and some find/replace.