### PR TITLE
Delete old stdlibs files when redownloading

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -50,6 +50,9 @@ if(EXISTS ${STDLIB_PATH}/stdlibs.zip)
     file(${STDLIB_HASHTYPE} ${STDLIB_PATH}/stdlibs.zip FOUND_HASH)
 endif()
 if(NOT EXISTS ${STDLIB_PATH}/stdlibs.zip OR NOT STDLIB_HASH STREQUAL "${STDLIB_HASHTYPE}=${FOUND_HASH}")
+    # remove old files before downloading
+    file(REMOVE_RECURSE ${STDLIB_PATH}/pic/ ${STDLIB_PATH}/no-pic/)
+
     message("Downloading stdlibs...")
 endif()
 


### PR DESCRIPTION
If we were re-downloading the stdlibs because the hash changed, we wouldn't extract it later because the dir already existed.

I only noticed this because my build script was failing to link everything after a system upgrade. (That is _after_ working around the python annoyingness with the tools...)