### PR TITLE
SDL screen mode/size improvements

### DIFF
--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -10,6 +10,17 @@ if (NOT DEFINED BLIT_ONCE)
 	# make sure that the tools are installed
 	execute_process(COMMAND ${PYTHON_EXECUTABLE} -m ttblit version RESULT_VARIABLE VERSION_STATUS OUTPUT_VARIABLE TOOLS_VERSION ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+	if(${VERSION_STATUS})
+		# check for the executable if the module isn't found
+		find_program(32BLIT_TOOLS_EXECUTABLE 32blit)
+		if(32BLIT_TOOLS_EXECUTABLE)
+			# get the version
+			execute_process(COMMAND ${32BLIT_TOOLS_EXECUTABLE} version RESULT_VARIABLE VERSION_STATUS OUTPUT_VARIABLE TOOLS_VERSION ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+		endif()
+	else()
+		set(32BLIT_TOOLS_EXECUTABLE ${PYTHON_EXECUTABLE} -m ttblit)
+	endif()
+
 	# get just the python command to output to the user
 	get_filename_component(PYTHON_USER_EXECUTABLE "${PYTHON_EXECUTABLE}" NAME)
 
@@ -37,7 +48,7 @@ if (NOT DEFINED BLIT_ONCE)
 
 		# get the inputs/outputs for the asset tool (at configure time)
 		execute_process(
-		    COMMAND ${PYTHON_EXECUTABLE} -m ttblit --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake
+		    COMMAND ${32BLIT_TOOLS_EXECUTABLE} --debug cmake --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR} --cmake ${CMAKE_CURRENT_BINARY_DIR}/assets.cmake
             RESULT_VARIABLE TOOL_RESULT
 		)
 		if(${TOOL_RESULT})
@@ -49,7 +60,7 @@ if (NOT DEFINED BLIT_ONCE)
 		# do asset packing (at build time)
 		add_custom_command(
 			OUTPUT ${ASSET_OUTPUTS}
-			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit --debug  pack --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR}
+			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} --debug  pack --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR}
 			DEPENDS ${ASSET_DEPENDS} ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
 		)
 

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -179,7 +179,7 @@ function(blit_metadata TARGET FILE)
 
     # get the inputs/outputs for the asset tool (at configure time)
     execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+        COMMAND ${32BLIT_TOOLS_EXECUTABLE} cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
         RESULT_VARIABLE TOOL_RESULT
     )
     if(${TOOL_RESULT})
@@ -193,7 +193,7 @@ function(blit_metadata TARGET FILE)
 
     add_custom_command(
         OUTPUT ${METADATA_SOURCE}
-        COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --force --config ${FILE} --pico-bi ${METADATA_SOURCE}
+        COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --force --config ${FILE} --pico-bi ${METADATA_SOURCE}
         DEPENDS ${FILE}
     )
 

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -221,7 +221,7 @@ function(blit_metadata TARGET FILE)
 
 	# parse the metadata to variables
 	execute_process(
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
 		RESULT_VARIABLE TOOL_RESULT
 	)
 	if(${TOOL_RESULT})
@@ -244,7 +244,7 @@ function(blit_metadata TARGET FILE)
 
 		add_custom_command(
 			OUTPUT ${ICON}
-			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --force --config ${FILE} --icns ${ICON}
+			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --force --config ${FILE} --icns ${ICON}
 			DEPENDS ${METADATA_DEPENDS} ${FILE}
 		)
 

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -165,8 +165,16 @@ int main(int argc, char *argv[]) {
 			mp_mode = Multiplayer::Mode::Listen;
 		else if(arg_str == "--position") {
 			SDL_sscanf(argv[i+1], "%d,%d", &x, &y);
-		}
-		else if(arg_str == "--credits") {
+		}	else if(arg_str == "--size" && i + 1 < argc) {
+      int w, h;
+			if(SDL_sscanf(argv[i+1], "%d,%d", &w, &h) == 2) {
+        if(w * y < System::max_width * System::max_height) {
+          System::width = w;
+          System::height = h;
+        }
+      }
+      i++;
+		} else if(arg_str == "--credits") {
 			std::cout << "32Blit was made possible by:" << std::endl;
 			std::cout << std::endl;
 			for(auto name : contributors) {
@@ -199,6 +207,7 @@ int main(int argc, char *argv[]) {
 			std::cout << " --connect <addr>     -- Connect to a listening game instance." << std::endl;
 			std::cout << " --listen             -- Listen for incoming connections." << std::endl;
 			std::cout << " --position x,y       -- Set window position." << std::endl;
+      std::cout << " --size w,h           -- Set display size. (max 320x240)" << std::endl;
 			std::cout << " --launch_path <file> -- Emulates the file associations on the console." << std::endl;
 			std::cout << " --credits            -- Print contributor credits and exit." << std::endl;
 			std::cout << " --info               -- Print metadata info and exit." << std::endl << std::endl;

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -143,8 +143,7 @@ void em_loop() {
 #endif
 
 int main(int argc, char *argv[]) {
-  int x, y;
-  bool custom_window_position = false;
+  int x = SDL_WINDOWPOS_UNDEFINED, y = SDL_WINDOWPOS_UNDEFINED;
 
   std::cout << metadata_title << " " << metadata_version << std::endl;
   std::cout << "Powered by 32Blit SDL2 runtime - github.com/32blit/32blit-sdk" << std::endl << std::endl;
@@ -165,9 +164,7 @@ int main(int argc, char *argv[]) {
 		else if(arg_str == "--listen")
 			mp_mode = Multiplayer::Mode::Listen;
 		else if(arg_str == "--position") {
-			if(SDL_sscanf(argv[i+1], "%d,%d", &x, &y) == 2) {
-			    custom_window_position = true;
-			}
+			SDL_sscanf(argv[i+1], "%d,%d", &x, &y);
 		}
 		else if(arg_str == "--credits") {
 			std::cout << "32Blit was made possible by:" << std::endl;
@@ -218,7 +215,7 @@ int main(int argc, char *argv[]) {
 
 	window = SDL_CreateWindow(
 		metadata_title,
-		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+		x, y,
 		System::width*2, System::height*2,
 		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
 	);
@@ -228,10 +225,6 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 	SDL_SetWindowMinimumSize(window, System::width, System::height);
-
-	if(custom_window_position) {
-		SDL_SetWindowPosition(window, x, y);
-	}
 
   blit_system = new System();
   blit_input = new Input(blit_system);

--- a/32blit-sdl/Main.cpp
+++ b/32blit-sdl/Main.cpp
@@ -144,6 +144,7 @@ void em_loop() {
 
 int main(int argc, char *argv[]) {
   int x = SDL_WINDOWPOS_UNDEFINED, y = SDL_WINDOWPOS_UNDEFINED;
+  bool fullscreen = false;
 
   std::cout << metadata_title << " " << metadata_version << std::endl;
   std::cout << "Powered by 32Blit SDL2 runtime - github.com/32blit/32blit-sdk" << std::endl << std::endl;
@@ -174,7 +175,9 @@ int main(int argc, char *argv[]) {
         }
       }
       i++;
-		} else if(arg_str == "--credits") {
+		} else if(arg_str == "--fullscreen")
+			fullscreen = true;
+    else if(arg_str == "--credits") {
 			std::cout << "32Blit was made possible by:" << std::endl;
 			std::cout << std::endl;
 			for(auto name : contributors) {
@@ -226,7 +229,7 @@ int main(int argc, char *argv[]) {
 		metadata_title,
 		x, y,
 		System::width*2, System::height*2,
-		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
+		SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | (fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0)
 	);
 
 	if (window == nullptr) {

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -339,7 +339,7 @@ void System::update_texture(SDL_Texture *texture) {
   auto stride = (is_lores ? width / 2 : width) * blit::pixel_format_stride[int(cur_format)];
 
   if(cur_format == blit::PixelFormat::P) {
-    uint8_t col_fb[width * height * 3];
+    uint8_t col_fb[max_width * max_height * 3];
 
     auto in = framebuffer, out = col_fb;
     auto size = is_lores ? (width / 2) * (height / 2) : width * height;

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -15,8 +15,11 @@
 
 extern Input *blit_input;
 
+int System::width = System::max_width;
+int System::height = System::max_height;
+
 // blit framebuffer memory
-static uint8_t framebuffer[System::width * System::height * 3];
+static uint8_t framebuffer[System::max_width * System::max_height * 3];
 static blit::Pen palette[256];
 
 // blit debug callback

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -33,23 +33,6 @@ blit::ScreenMode _mode = blit::ScreenMode::lores;
 static blit::PixelFormat cur_format = blit::PixelFormat::RGB;
 
 blit::SurfaceInfo cur_surf_info;
-blit::SurfaceInfo &set_screen_mode(blit::ScreenMode new_mode) {
-	_mode = new_mode;
-  switch(_mode) {
-    case blit::ScreenMode::lores:
-      cur_surf_info = __fb_lores;
-      break;
-    case blit::ScreenMode::hires:
-      cur_surf_info = __fb_hires;
-      break;
-    case blit::ScreenMode::hires_palette:
-      cur_surf_info = __fb_hires_pal;
-      break;
-  }
-
-  cur_format = cur_surf_info.format;
-	return cur_surf_info;
-}
 
 static void set_screen_palette(const blit::Pen *colours, int num_cols) {
 	memcpy(palette, colours, num_cols * sizeof(blit::Pen));
@@ -84,6 +67,20 @@ static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTempl
   cur_format = new_surf_template.format;
 
   return true;
+}
+
+blit::SurfaceInfo &set_screen_mode(blit::ScreenMode new_mode) {
+  blit::SurfaceTemplate temp{nullptr, {0, 0}, new_mode == blit::ScreenMode::hires_palette ? blit::PixelFormat::P : blit::PixelFormat::RGB};
+
+  // won't fail for the modes used here
+  set_screen_mode_format(new_mode, temp);
+
+  cur_surf_info.data = temp.data;
+  cur_surf_info.bounds = temp.bounds;
+  cur_surf_info.format = temp.format;
+  cur_surf_info.palette = temp.palette;
+
+  return cur_surf_info;
 }
 
 // blit timer callback

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -26,7 +26,9 @@ void blit_debug(const char *message) {
 
 // blit screenmode callback
 blit::ScreenMode _mode = blit::ScreenMode::lores;
+static blit::ScreenMode requested_mode = blit::ScreenMode::lores;
 static blit::PixelFormat cur_format = blit::PixelFormat::RGB;
+static blit::PixelFormat requested_format = blit::PixelFormat::RGB;
 
 blit::SurfaceInfo cur_surf_info;
 
@@ -59,8 +61,8 @@ static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTempl
       return false;
   }
 
-  _mode = new_mode;
-  cur_format = new_surf_template.format;
+  requested_mode = new_mode;
+  requested_format = new_surf_template.format;
 
   return true;
 }
@@ -308,6 +310,11 @@ void System::loop() {
   {
     blit::render(time_now);
     last_render_time = time_now;
+
+    if(_mode != requested_mode || cur_format != requested_format) {
+      _mode = requested_mode;
+      cur_format = requested_format;
+    }
   }
 
   blit::tick(::now());

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -19,10 +19,6 @@ extern Input *blit_input;
 static uint8_t framebuffer[System::width * System::height * 3];
 static blit::Pen palette[256];
 
-static const blit::SurfaceTemplate __fb_hires{framebuffer, blit::Size(System::width, System::height), blit::PixelFormat::RGB, nullptr};
-static const blit::SurfaceTemplate __fb_hires_pal{framebuffer, blit::Size(System::width, System::height), blit::PixelFormat::P, palette};
-static const blit::SurfaceTemplate __fb_lores{framebuffer, blit::Size(System::width / 2, System::height / 2), blit::PixelFormat::RGB, nullptr};
-
 // blit debug callback
 void blit_debug(const char *message) {
 	std::cout << message;
@@ -43,11 +39,11 @@ static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTempl
 
   switch(new_mode) {
     case blit::ScreenMode::lores:
-      new_surf_template.bounds = __fb_lores.bounds;
+      new_surf_template.bounds = blit::Size(System::width / 2, System::height / 2);
       break;
     case blit::ScreenMode::hires:
     case blit::ScreenMode::hires_palette:
-      new_surf_template.bounds = __fb_hires.bounds;
+      new_surf_template.bounds = blit::Size(System::width, System::height);
       break;
   }
 

--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -3,8 +3,11 @@ class System {
 		static const Uint32 timer_event;
 		static const Uint32 loop_event;
 
-		static const int width = 320;
-		static const int height = 240;
+    static const int max_width = 320;
+    static const int max_height = 240;
+
+		static int width;
+		static int height;
 
 		System();
 		~System();

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -186,6 +186,6 @@ function(blit_executable_int_flash NAME SOURCES)
 
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.dfu"
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit dfu build --force --output-file ${NAME}.dfu --input-file ${NAME}.bin
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} dfu build --force --output-file ${NAME}.dfu --input-file ${NAME}.bin
 	)
 endfunction()

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -52,10 +52,10 @@ function(blit_executable NAME)
 
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.blit"
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit relocs --elf-file $<TARGET_FILE:${NAME}> --bin-file ${NAME}.bin --output ${BLIT_FILENAME}
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} relocs --elf-file $<TARGET_FILE:${NAME}> --bin-file ${NAME}.bin --output ${BLIT_FILENAME}
 	)
 
-	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${PYTHON_EXECUTABLE} -m ttblit install --port=${FLASH_PORT} --launch ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
+	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOLS_EXECUTABLE} install --port=${FLASH_PORT} --launch ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
 endfunction()
 
 function(blit_metadata TARGET FILE)
@@ -68,7 +68,7 @@ function(blit_metadata TARGET FILE)
 
 	# get the inputs/outputs for the asset tool (at configure time)
 	execute_process(
-		COMMAND ${PYTHON_EXECUTABLE} -m ttblit cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
+		COMMAND ${32BLIT_TOOLS_EXECUTABLE} cmake --config ${FILE} --cmake ${CMAKE_CURRENT_BINARY_DIR}/metadata.cmake
 		RESULT_VARIABLE TOOL_RESULT
 	)
 	if(${TOOL_RESULT})
@@ -85,7 +85,7 @@ function(blit_metadata TARGET FILE)
 
 	add_custom_command(
 		TARGET ${TARGET} POST_BUILD
-		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${PYTHON_EXECUTABLE} -m ttblit metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
+		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
 	)
 
 	# force relink on change so that the post-build commands are rerun

--- a/32blit/graphics/primitive.cpp
+++ b/32blit/graphics/primitive.cpp
@@ -33,7 +33,7 @@ namespace blit {
       return;
     }
 
-    for (uint8_t y = cr.y; y < cr.y + cr.h; y++) {
+    for (int32_t y = cr.y; y < cr.y + cr.h; y++) {
       pbf(&pen, this, o, cr.w);
       o += bounds.w;
     }

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -1,6 +1,6 @@
 # embed the built firmware
 add_custom_command(
-    COMMAND ${PYTHON_EXECUTABLE} -m ttblit raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
+    COMMAND ${32BLIT_TOOLS_EXECUTABLE} raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
     OUTPUT firmware.hpp
     DEPENDS firmware
 )


### PR DESCRIPTION
Syncs SDL screen mode handling with the other ports and allows overriding the screen size on the command line. (Can finally test picosystem things in SDL without hacking the sources)

Also fixes a bug with surfaces taller than 255. (I tried 240x320 for fun).


(I definitely did this because of the picosystem thing and not because of blitsim.)