### PR TITLE
pico: remove blit_executable_common

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -164,11 +164,6 @@ target_compile_definitions(BlitHalPico INTERFACE ${BLIT_BOARD_DEFINITIONS})
 target_link_libraries(BlitHalPico INTERFACE ${BLIT_BOARD_LIBRARIES})
 
 # functions
-function(blit_executable_common NAME)
-    target_link_libraries(${NAME} BlitEngine)
-
-endfunction()
-
 function(blit_executable NAME)
     message(STATUS "Processing ${NAME}")
     blit_executable_args(${ARGN})


### PR DESCRIPTION
Unused, probably copied from 32blit-stm32. 

Just a random thing spotted while in the area...