### PR TITLE
pico: include config in led.cpp

### DIFF
--- a/32blit-pico/led.cpp
+++ b/32blit-pico/led.cpp
@@ -6,6 +6,8 @@
 #include "hardware/pwm.h"
 #include "pico/binary_info.h"
 
+#include "config.h"
+
 #include "engine/api_private.hpp"
 
 #if defined(LED_R_PIN) && defined(LED_G_PIN) && defined(LED_B_PIN)


### PR DESCRIPTION
Otherwise the LED is never going to get enabled (broken by #827 as this file still compiles without its #defines, it just does nothing)