### PR TITLE
Add VERBATIM to CMake custom commands

### DIFF
--- a/32blit-config.cmake
+++ b/32blit-config.cmake
@@ -62,6 +62,7 @@ if (NOT DEFINED BLIT_ONCE)
 			OUTPUT ${ASSET_OUTPUTS}
 			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} --debug  pack --force --config ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} --output ${CMAKE_CURRENT_BINARY_DIR}
 			DEPENDS ${ASSET_DEPENDS} ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
+			VERBATIM
 		)
 
 		# add the outputs as dependencies of the project (also compile any cpp files)

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -208,6 +208,7 @@ function(blit_metadata TARGET FILE)
         OUTPUT ${METADATA_SOURCE}
         COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --force --config ${FILE} --pico-bi ${METADATA_SOURCE}
         DEPENDS ${FILE}
+        VERBATIM
     )
 
     # add the generated source

--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -174,6 +174,7 @@ function(blit_executable NAME)
     		COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			"${DLL}"
 			$<TARGET_FILE_DIR:${NAME}>
+			VERBATIM
 		)
 	endforeach()
 
@@ -246,6 +247,7 @@ function(blit_metadata TARGET FILE)
 			OUTPUT ${ICON}
 			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --force --config ${FILE} --icns ${ICON}
 			DEPENDS ${METADATA_DEPENDS} ${FILE}
+			VERBATIM
 		)
 
 		target_sources(${TARGET} PRIVATE ${ICON})

--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -187,5 +187,6 @@ function(blit_executable_int_flash NAME SOURCES)
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.dfu"
 		COMMAND ${32BLIT_TOOLS_EXECUTABLE} dfu build --force --output-file ${NAME}.dfu --input-file ${NAME}.bin
+		VERBATIM
 	)
 endfunction()

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -10,6 +10,7 @@ function(blit_executable_common NAME)
 		COMMENT "Building ${NAME}.bin"
 		COMMAND ${CMAKE_OBJCOPY} -O binary -S $<TARGET_FILE:${NAME}> ${NAME}.bin
 		COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${NAME}>
+		VERBATIM
 	)
 endfunction()
 
@@ -53,6 +54,7 @@ function(blit_executable NAME)
 	add_custom_command(TARGET ${NAME} POST_BUILD
 		COMMENT "Building ${NAME}.blit"
 		COMMAND ${32BLIT_TOOLS_EXECUTABLE} relocs --elf-file $<TARGET_FILE:${NAME}> --bin-file ${NAME}.bin --output ${BLIT_FILENAME}
+		VERBATIM
 	)
 
 	add_custom_target(${NAME}.flash DEPENDS ${NAME} COMMAND ${32BLIT_TOOLS_EXECUTABLE} install --port=${FLASH_PORT} --launch ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME})
@@ -86,6 +88,7 @@ function(blit_metadata TARGET FILE)
 	add_custom_command(
 		TARGET ${TARGET} POST_BUILD
 		COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${32BLIT_TOOLS_EXECUTABLE} metadata --config ${FILE} --file ${CMAKE_CURRENT_BINARY_DIR}/${BLIT_FILENAME}
+		VERBATIM
 	)
 
 	# force relink on change so that the post-build commands are rerun

--- a/firmware-update/CMakeLists.txt
+++ b/firmware-update/CMakeLists.txt
@@ -3,6 +3,7 @@ add_custom_command(
     COMMAND ${32BLIT_TOOLS_EXECUTABLE} raw --force --input_file $<TARGET_FILE_DIR:firmware>/firmware.bin --symbol_name firmware_data  --output_file firmware.hpp
     OUTPUT firmware.hpp
     DEPENDS firmware
+    VERBATIM
 )
 
 blit_executable(firmware-update firmware-update.cpp firmware.hpp)


### PR DESCRIPTION
Someone thought using a build dir with () in it was a good idea, resulting in a lot of
```
/bin/sh: -c: line 1: syntax error near unexpected token `('
```

Adding this magic flag ~~allows them to continue making poor choices~~ fixes that problem.

Also the CMake docs say that this is a good idea:

     Use of VERBATIM is recommended as it enables correct behavior.