### PR TITLE
Some screen mode refactoring

### DIFF
--- a/32blit-pico/config.h
+++ b/32blit-pico/config.h
@@ -8,6 +8,10 @@
 #define ALLOW_HIRES 1
 #endif
 
+#ifndef DEFAULT_SCREEN_FORMAT
+#define DEFAULT_SCREEN_FORMAT PixelFormat::RGB565
+#endif
+
 #ifndef DISPLAY_WIDTH
 #ifdef DISPLAY_ST7789
 #define DISPLAY_WIDTH 240

--- a/32blit-pico/display.cpp
+++ b/32blit-pico/display.cpp
@@ -24,7 +24,7 @@ static volatile bool do_render = true;
 // blit api
 
 SurfaceInfo &set_screen_mode(ScreenMode mode) {
-  SurfaceTemplate temp{nullptr, {0, 0}, mode == ScreenMode::hires_palette ? PixelFormat::P : PixelFormat::RGB565};
+  SurfaceTemplate temp{nullptr, {0, 0}, mode == ScreenMode::hires_palette ? PixelFormat::P : DEFAULT_SCREEN_FORMAT};
 
   // may fail for hires/palette
   if(set_screen_mode_format(mode, temp)) {

--- a/32blit-pico/display.cpp
+++ b/32blit-pico/display.cpp
@@ -60,7 +60,7 @@ bool set_screen_mode_format(ScreenMode new_mode, SurfaceTemplate &new_surf_templ
   if(!display_mode_supported(new_mode, new_surf_template))
     return false;
 
-  display_mode_changed(new_mode);
+  display_mode_changed(new_mode, new_surf_template);
 
   cur_screen_mode = new_mode;
 

--- a/32blit-pico/display.cpp
+++ b/32blit-pico/display.cpp
@@ -40,6 +40,9 @@ SurfaceInfo &set_screen_mode(ScreenMode mode) {
 bool set_screen_mode_format(ScreenMode new_mode, SurfaceTemplate &new_surf_template) {
   new_surf_template.data = (uint8_t *)screen_fb;
 
+  if(new_surf_template.format == (PixelFormat)-1)
+    new_surf_template.format = DEFAULT_SCREEN_FORMAT;
+
   switch(new_mode) {
     case ScreenMode::lores:
       new_surf_template.bounds = lores_screen_size;

--- a/32blit-pico/display.cpp
+++ b/32blit-pico/display.cpp
@@ -54,11 +54,10 @@ bool set_screen_mode_format(ScreenMode new_mode, SurfaceTemplate &new_surf_templ
 #endif
   }
 
-  display_mode_changed(new_mode);
-
-  // don't support any other formats for various reasons (RAM, no format conversion, pixel double PIO)
-  if(new_surf_template.format != PixelFormat::RGB565)
+  if(!display_mode_supported(new_mode, new_surf_template))
     return false;
+
+  display_mode_changed(new_mode);
 
   cur_screen_mode = new_mode;
 

--- a/32blit-pico/display.cpp
+++ b/32blit-pico/display.cpp
@@ -45,12 +45,18 @@ bool set_screen_mode_format(ScreenMode new_mode, SurfaceTemplate &new_surf_templ
 
   switch(new_mode) {
     case ScreenMode::lores:
-      new_surf_template.bounds = lores_screen_size;
+      if(new_surf_template.bounds.empty())
+        new_surf_template.bounds = lores_screen_size;
+      else
+        new_surf_template.bounds /= 2;
+
       break;
     case ScreenMode::hires:
     case ScreenMode::hires_palette:
 #if ALLOW_HIRES
-      new_surf_template.bounds = hires_screen_size;
+      if(new_surf_template.bounds.empty())
+        new_surf_template.bounds = hires_screen_size;
+
       break;
 #else
       return false; // no hires for scanvideo

--- a/32blit-pico/display.hpp
+++ b/32blit-pico/display.hpp
@@ -21,7 +21,7 @@ bool display_render_needed();
 
 bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template);
 
-void display_mode_changed(blit::ScreenMode new_mode);
+void display_mode_changed(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template);
 
 blit::SurfaceInfo &set_screen_mode(blit::ScreenMode mode);
 bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template);

--- a/32blit-pico/display.hpp
+++ b/32blit-pico/display.hpp
@@ -19,6 +19,8 @@ void update_display_core1();
 
 bool display_render_needed();
 
+bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template);
+
 void display_mode_changed(blit::ScreenMode new_mode);
 
 blit::SurfaceInfo &set_screen_mode(blit::ScreenMode mode);

--- a/32blit-pico/display_none.cpp
+++ b/32blit-pico/display_none.cpp
@@ -18,5 +18,9 @@ bool display_render_needed() {
   return false;
 }
 
+bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template) {
+  return false;
+}
+
 void display_mode_changed(blit::ScreenMode new_mode) {
 }

--- a/32blit-pico/display_none.cpp
+++ b/32blit-pico/display_none.cpp
@@ -22,5 +22,5 @@ bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTempla
   return false;
 }
 
-void display_mode_changed(blit::ScreenMode new_mode) {
+void display_mode_changed(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {
 }

--- a/32blit-pico/display_scanvideo.cpp
+++ b/32blit-pico/display_scanvideo.cpp
@@ -113,7 +113,15 @@ bool display_render_needed() {
 }
 
 bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template) {
-  return new_surf_template.format == blit::PixelFormat::RGB565;
+  if(new_surf_template.format != blit::PixelFormat::RGB565)
+    return false;
+
+  blit::Size expected_bounds(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+
+  if(new_surf_template.bounds == expected_bounds || new_surf_template.bounds == expected_bounds / 2)
+    return true;
+
+  return false;
 }
 
 void display_mode_changed(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {

--- a/32blit-pico/display_scanvideo.cpp
+++ b/32blit-pico/display_scanvideo.cpp
@@ -116,5 +116,5 @@ bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTempla
   return new_surf_template.format == blit::PixelFormat::RGB565;
 }
 
-void display_mode_changed(blit::ScreenMode new_mode) {
+void display_mode_changed(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {
 }

--- a/32blit-pico/display_scanvideo.cpp
+++ b/32blit-pico/display_scanvideo.cpp
@@ -112,5 +112,9 @@ bool display_render_needed() {
   return do_render;
 }
 
+bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template) {
+  return new_surf_template.format == blit::PixelFormat::RGB565;
+}
+
 void display_mode_changed(blit::ScreenMode new_mode) {
 }

--- a/32blit-pico/display_st7789.cpp
+++ b/32blit-pico/display_st7789.cpp
@@ -71,7 +71,7 @@ bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTempla
   return new_surf_template.format == blit::PixelFormat::RGB565;
 }
 
-void display_mode_changed(blit::ScreenMode new_mode) {
+void display_mode_changed(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {
   if(have_vsync)
     do_render = true; // prevent starting an update during switch
 

--- a/32blit-pico/display_st7789.cpp
+++ b/32blit-pico/display_st7789.cpp
@@ -68,7 +68,16 @@ bool display_render_needed() {
 }
 
 bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template) {
-  return new_surf_template.format == blit::PixelFormat::RGB565;
+  if(new_surf_template.format != blit::PixelFormat::RGB565)
+    return false;
+
+  // TODO: could allow smaller sizes with window
+  blit::Size expected_bounds(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+
+  if(new_surf_template.bounds == expected_bounds || new_surf_template.bounds == expected_bounds / 2)
+    return true;
+
+  return false;
 }
 
 void display_mode_changed(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {

--- a/32blit-pico/display_st7789.cpp
+++ b/32blit-pico/display_st7789.cpp
@@ -67,6 +67,10 @@ bool display_render_needed() {
   return do_render;
 }
 
+bool display_mode_supported(blit::ScreenMode new_mode, const blit::SurfaceTemplate &new_surf_template) {
+  return new_surf_template.format == blit::PixelFormat::RGB565;
+}
+
 void display_mode_changed(blit::ScreenMode new_mode) {
   if(have_vsync)
     do_render = true; // prevent starting an update during switch

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -42,6 +42,9 @@ static void set_screen_palette(const blit::Pen *colours, int num_cols) {
 static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTemplate &new_surf_template) {
   new_surf_template.data = framebuffer;
 
+  if(new_surf_template.format == (blit::PixelFormat)-1)
+    new_surf_template.format = blit::PixelFormat::RGB;
+
   switch(new_mode) {
     case blit::ScreenMode::lores:
       new_surf_template.bounds = blit::Size(System::width / 2, System::height / 2);

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -140,6 +140,9 @@ namespace display {
   bool set_screen_mode_format(ScreenMode new_mode, SurfaceTemplate &new_surf_template) {
     new_surf_template.data = (uint8_t *)&__fb_start;
 
+    if(new_surf_template.format == (blit::PixelFormat)-1)
+      new_surf_template.format = blit::PixelFormat::RGB;
+
     switch(new_mode) {
       case ScreenMode::lores:
         new_surf_template.bounds = lores_screen_size;

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -14,9 +14,10 @@ namespace blit {
   void (*render)(uint32_t time)                     = nullptr;
 
   void set_screen_mode(ScreenMode new_mode) {
-    auto &new_screen = api.set_screen_mode(new_mode);
-    screen = Surface(new_screen.data, new_screen.format, new_screen.bounds);
-    screen.palette = new_screen.palette;
+    if(new_mode == ScreenMode::hires_palette)
+      set_screen_mode(ScreenMode::hires, PixelFormat::P);
+    else
+      set_screen_mode(new_mode, (PixelFormat)-1);
   }
 
   bool set_screen_mode(ScreenMode new_mode, PixelFormat format) {

--- a/32blit/graphics/surface.hpp
+++ b/32blit/graphics/surface.hpp
@@ -73,11 +73,13 @@ namespace blit {
   };
 
   enum class PixelFormat {
-    RGB = 0,   // red, green, blue (8-bits per channel)
-    RGBA = 1,  // red, green, blue, alpha (8-bits per channel)
-    P = 2,     // palette entry (8-bits) into attached palette
-    M = 3,     // mask (8-bits, single channel)
-    RGB565 = 4
+    RGB = 0,    // red, green, blue (8-bits per channel)
+    RGBA = 1,   // red, green, blue, alpha (8-bits per channel)
+    P = 2,      // palette entry (8-bits) into attached palette
+    M = 3,      // mask (8-bits, single channel)
+
+    // supported as the screen format
+    RGB565 = 4, // red (5-bits), green (6-bits), blue (5bits)
   };
 
   static const uint8_t pixel_format_stride[] = {


### PR DESCRIPTION
Non-picovision screen-related changes from that branch (in an attempt to clean it up to not break other things).

Most break-y change is always using `set_screen_mode_format` at the API level to simplify some stuff. (Could probably delete the old one from -sdl/-pico after this).

Tested on SDL, 32blit, PicoSystem and VGA board... I think.

(Still not sure about `(PixelFormat)-1`, but also didn't want to think about `Surface(..., PixelFormat::Default)` being a thing)