### PR TITLE
sdl: add extra search dir for fixup_bundle

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -193,7 +193,7 @@ function(blit_executable NAME)
 	endif()
 
 	if(APPLE)
-		set(SEARCH_DIRS)
+		set(SEARCH_DIRS /usr/local/lib)
 
 		# assuming all frameworks installed in the same place
 		if(SDL2_FRAMEWORK_PATH)


### PR DESCRIPTION
Boilerplate macOS builds are failing (on release or if you have added artefacts), probably due to some update in brew's SDL build (?). This should fix it (it does locally).

The SDK itself is unaffected as it uses a fixed version of the SDL framework. (Which also allows arm builds... not that I have anything to run those on)