### PR TITLE
More PicoVision modes

### DIFF
--- a/32blit-sdl/Renderer.cpp
+++ b/32blit-sdl/Renderer.cpp
@@ -16,7 +16,7 @@ Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width)
 		std::cerr << "could not create renderer: " << SDL_GetError() << std::endl;
 	}
 
-	current = fb_hires_texture;
+  current = fb_texture;
 
 	int w, h;
 	SDL_GetWindowSize(window, &w, &h);
@@ -28,17 +28,13 @@ Renderer::Renderer(SDL_Window *window, int width, int height) : sys_width(width)
 	SDL_RenderClear(renderer);
 	SDL_RenderPresent(renderer);
 
-  fb_lores_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
-	fb_hires_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
-  fb_lores_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width/2, sys_height/2);
-  fb_hires_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
+  fb_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
+  fb_565_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING, sys_width, sys_height);
 }
 
 Renderer::~Renderer() {
-	SDL_DestroyTexture(fb_lores_texture);
-	SDL_DestroyTexture(fb_hires_texture);
-	SDL_DestroyTexture(fb_lores_565_texture);
-	SDL_DestroyTexture(fb_hires_565_texture);
+	SDL_DestroyTexture(fb_texture);
+	SDL_DestroyTexture(fb_565_texture);
 	SDL_DestroyRenderer(renderer);
 }
 
@@ -70,11 +66,7 @@ void Renderer::resize(int width, int height) {
 void Renderer::update(System *sys) {
   auto format = blit::PixelFormat(sys->format());
 
-	if (sys->mode() == 0) {
-		current = format == blit::PixelFormat::RGB565 ? fb_lores_565_texture : fb_lores_texture;
-	} else {
-		current = format == blit::PixelFormat::RGB565 ? fb_hires_565_texture : fb_hires_texture;
-	}
+	current = format == blit::PixelFormat::RGB565 ? fb_565_texture : fb_texture;
 
   if(is_lores != (sys->mode() == 0)) {
     is_lores = sys->mode() == 0;
@@ -97,11 +89,6 @@ void Renderer::present() {
   dest.y = 0;
   dest.w = sys_width;
   dest.h = sys_height;
-
-  if (is_lores) {
-    dest.w /= 2;
-    dest.h /= 2;
-  }
 
 	_render(nullptr, &dest);
 	SDL_RenderPresent(renderer);

--- a/32blit-sdl/Renderer.hpp
+++ b/32blit-sdl/Renderer.hpp
@@ -23,9 +23,7 @@ class Renderer {
 		Mode mode = KeepPixels;
 		SDL_Renderer *renderer = nullptr;
 
-		SDL_Texture *fb_lores_texture = nullptr;
-		SDL_Texture *fb_hires_texture = nullptr;
-		SDL_Texture *fb_lores_565_texture = nullptr;
-		SDL_Texture *fb_hires_565_texture = nullptr;
+		SDL_Texture *fb_texture = nullptr;
+		SDL_Texture *fb_565_texture = nullptr;
 		SDL_Texture *current = nullptr;
 };

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -45,15 +45,22 @@ static bool set_screen_mode_format(blit::ScreenMode new_mode, blit::SurfaceTempl
   if(new_surf_template.format == (blit::PixelFormat)-1)
     new_surf_template.format = blit::PixelFormat::RGB;
 
+  blit::Size default_bounds(System::width, System::height);
+
+  if(new_surf_template.bounds.empty())
+    new_surf_template.bounds = default_bounds;
+
   switch(new_mode) {
     case blit::ScreenMode::lores:
-      new_surf_template.bounds = blit::Size(System::width / 2, System::height / 2);
+      new_surf_template.bounds /= 2;
       break;
     case blit::ScreenMode::hires:
     case blit::ScreenMode::hires_palette:
-      new_surf_template.bounds = blit::Size(System::width, System::height);
       break;
   }
+
+  if(new_surf_template.bounds != default_bounds && new_surf_template.bounds != default_bounds / 2)
+    return false;
 
   switch(new_surf_template.format) {
     case blit::PixelFormat::RGB:

--- a/32blit-sdl/System.cpp
+++ b/32blit-sdl/System.cpp
@@ -346,13 +346,15 @@ Uint32 System::format() {
 
 void System::update_texture(SDL_Texture *texture) {
   bool is_lores = _mode == blit::ScreenMode::lores;
-  auto stride = (is_lores ? width / 2 : width) * blit::pixel_format_stride[int(cur_format)];
+
+  SDL_Rect dest_rect{0, 0, is_lores ? width / 2 : width, is_lores ? height / 2 : height};
+  auto stride = dest_rect.w * blit::pixel_format_stride[int(cur_format)];
 
   if(cur_format == blit::PixelFormat::P) {
     uint8_t col_fb[max_width * max_height * 3];
 
     auto in = framebuffer, out = col_fb;
-    auto size = is_lores ? (width / 2) * (height / 2) : width * height;
+    auto size = dest_rect.w * dest_rect.h;
 
     for(int i = 0; i < size; i++) {
       uint8_t index = *(in++);
@@ -361,9 +363,9 @@ void System::update_texture(SDL_Texture *texture) {
       (*out++) = palette[index].b;
     }
 
-    SDL_UpdateTexture(texture, nullptr, col_fb, stride * 3);
+    SDL_UpdateTexture(texture, &dest_rect, col_fb, stride * 3);
   } else
-    SDL_UpdateTexture(texture, nullptr, framebuffer, stride);
+    SDL_UpdateTexture(texture, &dest_rect, framebuffer, stride);
 }
 
 void System::notify_redraw() {

--- a/32blit-stm32/Src/display.cpp
+++ b/32blit-stm32/Src/display.cpp
@@ -145,13 +145,21 @@ namespace display {
 
     switch(new_mode) {
       case ScreenMode::lores:
-        new_surf_template.bounds = lores_screen_size;
+        if(new_surf_template.bounds.empty())
+          new_surf_template.bounds = lores_screen_size;
+        else
+          new_surf_template.bounds /= 2;
         break;
       case ScreenMode::hires:
       case ScreenMode::hires_palette:
-        new_surf_template.bounds = hires_screen_size;
+        if(new_surf_template.bounds.empty())
+          new_surf_template.bounds = hires_screen_size;
         break;
     }
+
+    // only two resolutions supported
+    if(new_surf_template.bounds != lores_screen_size && new_surf_template.bounds != hires_screen_size)
+      return false;
 
     switch(new_surf_template.format) {
       case PixelFormat::RGB:

--- a/32blit/engine/engine.cpp
+++ b/32blit/engine/engine.cpp
@@ -13,16 +13,17 @@ namespace blit {
   void (*update)(uint32_t time)                     = nullptr;
   void (*render)(uint32_t time)                     = nullptr;
 
-  void set_screen_mode(ScreenMode new_mode) {
+  void set_screen_mode(ScreenMode new_mode, Size bounds) {
     if(new_mode == ScreenMode::hires_palette)
-      set_screen_mode(ScreenMode::hires, PixelFormat::P);
+      set_screen_mode(ScreenMode::hires, PixelFormat::P, bounds);
     else
-      set_screen_mode(new_mode, (PixelFormat)-1);
+      set_screen_mode(new_mode, (PixelFormat)-1, bounds);
   }
 
-  bool set_screen_mode(ScreenMode new_mode, PixelFormat format) {
+  bool set_screen_mode(ScreenMode new_mode, PixelFormat format, Size bounds) {
     SurfaceTemplate new_screen;
     new_screen.format = format;
+    new_screen.bounds = bounds;
 
     if(!api.set_screen_mode_format(new_mode, new_screen))
       return false;

--- a/32blit/engine/engine.hpp
+++ b/32blit/engine/engine.hpp
@@ -15,8 +15,8 @@ namespace blit {
   extern void     (*update)           (uint32_t time);
   extern void     (*render)           (uint32_t time);
 
-  void set_screen_mode(ScreenMode new_mode);
-  bool set_screen_mode(ScreenMode new_mode, PixelFormat format);
+  void set_screen_mode(ScreenMode new_mode, Size bounds = {0, 0});
+  bool set_screen_mode(ScreenMode new_mode, PixelFormat format, Size bounds = {0, 0});
   void set_screen_palette(const Pen *colours, int num_cols);
 
   uint32_t now();


### PR DESCRIPTION
First commit is enough to allow non-default modes by setting `DISPLAY_WIDTH/HEIGHT` to the desired `hires` resolution. The next three are so you can do it at runtime (or at least try to, non-picovision returns false for anything not the defaults).

Works most of the time... sometimes my mode test gets the red screen of death, but attempting to manually reproduce usually doesn't...


(+ bonus SDL cleanup because I was going to add more modes then realised it wouldn't be as simple as I thought)