### PR TITLE
Add can_launch API

### DIFF
--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -53,6 +53,13 @@ namespace blit {
     Pen *palette = nullptr;
   };
 
+  enum class CanLaunchResult {
+    Success = 0,
+    UnknownType,       /// no known handler for this file
+    InvalidFile,      /// file is not valid/doesn't exist
+    IncompatibleBlit, /// file is incompatible with this device
+  };
+
   #pragma pack(push, 4)
   struct API {
     uint16_t version_major;
@@ -135,6 +142,9 @@ namespace blit {
 
     // another launcher API
     void (*list_installed_games)(std::function<void(const uint8_t *, uint32_t, uint32_t)> callback);
+    // if launch is expected to succeed on this file
+    // files this returns success for should be .blit files or have a registered handler (get_type_handler_metadata should return valid metadata)
+    CanLaunchResult (*can_launch)(const char *path);
   };
   #pragma pack(pop)
 

--- a/firmware/firmware.cpp
+++ b/firmware/firmware.cpp
@@ -568,6 +568,45 @@ static void list_installed_games(std::function<void(const uint8_t *, uint32_t, u
     callback((const uint8_t *)(qspi_flash_address + game.offset), game.offset / qspi_flash_sector_size, game.size);
 }
 
+static CanLaunchResult can_launch(const char *path) {
+  if(strncmp(path, "flash:/", 7) == 0) {
+    // assume anything flashed is compatible for now
+    return CanLaunchResult::Success;
+  }
+
+  // get the extension
+  std::string_view sv(path);
+  auto last_dot = sv.find_last_of('.');
+  auto ext = last_dot == std::string::npos ? "" : std::string(sv.substr(last_dot + 1));
+  for(auto &c : ext)
+    c = tolower(c);
+
+  if(ext == "blit") {
+    BlitGameHeader header;
+    uint32_t header_offset;
+    FIL file;
+    FRESULT res = f_open(&file, path, FA_READ);
+    if(res != FR_OK)
+      return CanLaunchResult::InvalidFile;
+
+    if(parse_file_header(file, header, header_offset)) {
+      f_close(&file);
+      return CanLaunchResult::Success;
+    }
+
+    f_close(&file);
+    return CanLaunchResult::IncompatibleBlit;
+  }
+
+  // not a blit file, so we need to check for handlers
+  for(auto &handler : handlers) {
+    if(strncmp(ext.c_str(), handler.type, 4) == 0)
+      return CanLaunchResult::Success;
+  }
+
+  return CanLaunchResult::UnknownType;
+}
+
 static const uint8_t *flash_to_tmp(const std::string &filename, uint32_t &size) {
   // one file at a time
   // TODO: this could be improved
@@ -654,6 +693,7 @@ void init() {
   api.tmp_file_closed = tmp_file_closed;
 
   api.list_installed_games = list_installed_games;
+  api.can_launch = can_launch;
 
   scan_flash();
   flash_scanned = true;

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -177,7 +177,7 @@ static void load_file_list(const std::string &directory) {
   for(auto &file : files) {
     auto last_dot = file.name.find_last_of('.');
 
-    auto ext = file.name.substr(last_dot + 1);
+    auto ext = last_dot == std::string::npos ? "" : file.name.substr(last_dot + 1);
 
     for(auto &c : ext)
       c = tolower(c);


### PR DESCRIPTION
This is a few patches shared by the "SDL launcher" and "pico launcher" branches. Moves checking if a file can be launched over to the "firmware" side. Should allow better compatibility checks when combined with #822 (and less "Oops!").

Also makes it a little easier to implement alternative launchers. (Which _may_ be what made me dig these up...)