### PR TITLE
Fix pico metadata title

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -222,4 +222,7 @@ function(blit_metadata TARGET FILE)
     # add the generated source
     target_sources(${TARGET} PRIVATE ${METADATA_SOURCE})
 
+    # avoid the fallback to target name
+    target_compile_definitions(${TARGET} PRIVATE PICO_NO_BI_PROGRAM_NAME=1)
+
 endfunction()


### PR DESCRIPTION
The pico SDK sets a default program name if PICO_PROGRAM_NAME is not set. As we're specifying all the metadata using bi_decl directly, disable the fallback.