### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Install deps
       run: |
-        sudo apt update && sudo apt install doxygen graphviz python3-setuptools
-        pip3 install 32blit
+        sudo apt update && sudo apt install doxygen graphviz pipx
+        pipx install 32blit
 
     - name: Setup cache
       id: cache-system-libraries

--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Checkout Examples
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 32blit/32blit-examples
         path: 32blit-examples
@@ -34,13 +34,13 @@ jobs:
 
     - name: Setup cache
       id: cache-system-libraries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{env.EM_CACHE_FOLDER}}
         key: ${{env.EM_VERSION}}-${{runner.os}}
 
     - name: Setup Emscripten
-      uses: mymindstorm/setup-emsdk@v12
+      uses: mymindstorm/setup-emsdk@v14
       with:
         version: ${{env.EM_VERSION}}
         actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
@@ -74,7 +74,7 @@ jobs:
         cp ../build/*/*.{js,wasm} site/examples
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{github.event.repository.name}}-${{github.sha}}-web
         path: site
@@ -88,7 +88,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       if: github.ref == 'refs/heads/master' # github.event_name == 'release'
-      uses: crazy-max/ghaction-github-pages@v3
+      uses: crazy-max/ghaction-github-pages@v4
       with:
         target_branch: gh-pages
         build_dir: site

--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/Visual Studio.yml
+++ b/.github/workflows/Visual Studio.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Checkout Examples
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 32blit/32blit-examples
         path: examples
@@ -25,7 +25,7 @@ jobs:
         python -m pip install 32blit
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1.3
+      uses: microsoft/setup-msbuild@v2
 
     - name: Build
       run: msbuild.exe vs/32blit.sln

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -74,10 +74,10 @@ jobs:
 
     steps:
     - name: Checkout 32Blit SDK
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout Examples
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 32blit/32blit-examples
         path: examples
@@ -85,7 +85,7 @@ jobs:
     # pico sdk/extras for some builds
     - name: Checkout Pico SDK
       if: matrix.pico-sdk
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: raspberrypi/pico-sdk
         path: pico-sdk
@@ -93,7 +93,7 @@ jobs:
 
     - name: Checkout Pico Extras
       if: matrix.pico-sdk
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: raspberrypi/pico-extras
         path: pico-extras
@@ -101,14 +101,14 @@ jobs:
     # PicoVision needs the RAM driver and the firmware
     - name: Checkout PicoVision
       if: matrix.name == 'PicoVision'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: pimoroni/picovision
         ref: 03df7694ed4fb396c1d12adf90d0150ada6baedc
         path: picovision
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ccache-${{matrix.cache-key}}-${{github.ref}}-${{github.sha}}
@@ -181,7 +181,7 @@ jobs:
 
     - name: Upload Artifact
       if: github.event_name != 'release'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.RELEASE_FILE}}
         path: ${{runner.workspace}}/build/install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,14 +23,14 @@ jobs:
             cache-key: linux
             release-suffix: LIN64
             cmake-args: '"-DCMAKE_CXX_CLANG_TIDY=clang-tidy;-header-filter=(32blit|32blit-sdl)/;-checks=performance-*,portability-*,modernize-*,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
-            apt-packages: ccache clang-tidy libsdl2-dev libsdl2-image-dev libsdl2-net-dev python3-setuptools
+            apt-packages: ccache clang-tidy libsdl2-dev libsdl2-image-dev libsdl2-net-dev pipx python3-requests
 
           - os: ubuntu-22.04
             name: STM32
             cache-key: stm32
             release-suffix: STM32
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit.toolchain -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
+            apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib pipx python3-requests
 
           - os: ubuntu-22.04
             pico-sdk: true
@@ -38,7 +38,7 @@ jobs:
             cache-key: picosystem
             release-suffix: PicoSystem
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/pico.toolchain -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pimoroni_picosystem -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
+            apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib pipx python3-requests
 
           - os: ubuntu-22.04
             pico-sdk: true
@@ -46,14 +46,14 @@ jobs:
             cache-key: picovision
             release-suffix: PicoVision
             cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pico_w -DPICO_ADDON=pimoroni_picovision -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
+            apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib pipx python3-requests
 
           - os: ubuntu-22.04
             name: MinGW
             cache-key: mingw
             artifact-suffix: MinGW
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/mingw.toolchain -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSDL2_DIR=$GITHUB_WORKSPACE/SDL2/cmake -DSDL2_image_DIR=$GITHUB_WORKSPACE/SDL2_image/cmake -DSDL2_net_DIR=$GITHUB_WORKSPACE/SDL2_net/cmake
-            apt-packages: ccache g++-mingw-w64 python3-setuptools
+            apt-packages: ccache g++-mingw-w64 pipx python3-requests
 
           - os: macos-13
             name: macOS
@@ -121,7 +121,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ${{matrix.apt-packages}}
-        pip3 install 32blit requests
+        pipx install 32blit
 
     # macOS deps
     - name: Install deps

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,21 +18,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: Linux
             cache-key: linux
             release-suffix: LIN64
             cmake-args: '"-DCMAKE_CXX_CLANG_TIDY=clang-tidy;-header-filter=(32blit|32blit-sdl)/;-checks=performance-*,portability-*,modernize-*,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,-modernize-use-nodiscard" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
             apt-packages: ccache clang-tidy libsdl2-dev libsdl2-image-dev libsdl2-net-dev python3-setuptools
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: STM32
             cache-key: stm32
             release-suffix: STM32
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit.toolchain -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             pico-sdk: true
             name: PicoSystem
             cache-key: picosystem
@@ -40,7 +40,7 @@ jobs:
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/pico.toolchain -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pimoroni_picosystem -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             pico-sdk: true
             name: PicoVision
             cache-key: picovision
@@ -48,7 +48,7 @@ jobs:
             cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pico_w -DPICO_ADDON=pimoroni_picovision -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: MinGW
             cache-key: mingw
             artifact-suffix: MinGW


### PR DESCRIPTION
The usual version bumps for deprecation warnings, plus the ubuntu version as 20.04 is EOL next year (may also solve a problem I'm having)...

Need to make sure there are no surprises from the compiler version bump (though I'm locally using 14.1 so I hope not). Also might not want to use latest ubuntu to ensure wider compatibility :thinking: 

(22.04 is an arm gcc bump from 9 -> 10, 24.04 is -> 13)