### PR TITLE
sdl: copy/present only after rendering

### DIFF
--- a/32blit-sdl/System.hpp
+++ b/32blit-sdl/System.hpp
@@ -18,7 +18,7 @@ class System {
 		int update_thread();
 		int timer_thread();
 
-		void loop();
+		bool loop();
 
 		Uint32 mode();
     Uint32 format();


### PR DESCRIPTION
Instead of at 100Hz. Seems I broke this in #752... Only noticed because I hacked the video capture code back to life (again) and got a 2x slow video.