### PR TITLE
sdl: make include directories PUBLIC in fallback path

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
 		set(SDL2_LIBRARIES SDL2::SDL2main SDL2::SDL2-static)
 	else()
 		target_include_directories(BlitHalSDL
-			PRIVATE	${SDL2_INCLUDE_DIRS}
+			PUBLIC ${SDL2_INCLUDE_DIRS}
 		)
 	endif()
 
@@ -92,7 +92,7 @@ else()
 	find_sdl_lib(SDL2_net SDL_net.h)
 
 	target_include_directories(BlitHalSDL
-		PRIVATE	${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_NET_INCLUDE_DIR}
+		PUBLIC ${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_NET_INCLUDE_DIR}
 	)
 endif()
 


### PR DESCRIPTION
Because the library link is PUBLIC, when we have a new SDL2 with the targets defined, the include dirs also end up public. Change this in the fallback path for consistency.

This change is a result of me needing to call an SDL function in something as a workaround, which built fine locally... but blew up the actions build.