### PR TITLE
Fix Surface::line infinite loops

### DIFF
--- a/32blit/graphics/primitive.cpp
+++ b/32blit/graphics/primitive.cpp
@@ -155,12 +155,14 @@ namespace blit {
 
     Point p(p1);
 
+    int count = std::max(dx, -dy);
+
     while (true) {
       if (clip.contains(p)) {
         pbf(&pen, this, offset(p), 1);
       }
 
-      if ((p.x == p2.x) && (p.y == p2.y)) break;
+      if (count-- == 0) break;
 
       int32_t e2 = err * 2;
       if (e2 >= dy) { err += dy; p.x += sx; }


### PR DESCRIPTION
I had it hang again, so fixed it.

Instead of checking if we've reached the target, count how many pixels we should draw. I've verified that this is the same number of iterations (except not infinite sometimes) and is possibly a little faster (it certainly generates less code).

Fixes #504 ?