### PR TITLE
pico: revert using nano.specs

### DIFF
--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -180,7 +180,6 @@ function(blit_executable NAME)
 
     add_executable(${NAME} ${SOURCES})
     target_link_libraries(${NAME} BlitHalPico BlitEngine)
-    target_link_options(${NAME} PUBLIC -specs=nano.specs -u _printf_float)
 
     pico_enable_stdio_uart(${NAME} 1)
     pico_enable_stdio_usb(${NAME} 0)

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -25,6 +25,11 @@ using namespace blit;
 
 static blit::AudioChannel channels[CHANNEL_COUNT];
 
+// override terminate handler to save ~20-30k
+namespace __cxxabiv1 {
+  std::terminate_handler __terminate_handler = std::abort;
+}
+
 static uint32_t now() {
   return to_ms_since_boot(get_absolute_time());
 }


### PR DESCRIPTION
I added this to avoid bloat from exception related stuff in libstdc++, but there's a problem.

- `newlib-nano` is usually built with `-Os`, this results in disabling the optimised `memcpy`/`memset`/... implementations.
- The fallback implementation just copy/fill bytes. Very small, but not fast.
- RP2040 has an optimised `memcpy`/`memset` in the bootrom so these aren't used in the end. RP2350 does not... so they do.
- GCC tries to be smart and optimises anything that looks like a `memcpy` to a `memcpy` (similar for `memset`), but if you were copying words it makes it 4x slower.


So, this goes back to the default but tries to keep most of the space savings by avoiding the default terminate handler.

For a somewhat extreme performance comparison, this is 15 -> 10ms on my 3d engine (rasterise time).

Size comparison:

`logo` before (with `nano.specs`)
```
  text    data     bss     dec     hex filename
282432       0  319696  602128   93010 examples/logo/logo.elf
```

`logo` without `nano.specs`
```
  text    data     bss     dec     hex filename
313484       0  320524  634008   9ac98 examples/logo/logo.elf
```
(ouch, +31k)

`logo` after (without `nano.specs`, overridden terminate handler)
```
  text    data     bss     dec     hex filename
288736       0  320516  609252   94be4 examples/logo/logo.elf
```
(just +6.3k)


(32blit-stm32 has a similar problem, which we can fix there by [rebuilding our custom newlib with `-O2`](https://github.com/32blit/stdlibs/commit/201933adbb2a485771ebdb37cea4f971c1845406) (+3k on `logo`, +2.4k on `firmware`))