### PR TITLE
pico: SD storage fixes

### DIFF
--- a/32blit-pico/config.h
+++ b/32blit-pico/config.h
@@ -183,6 +183,10 @@
 #define OVERCLOCK_250 1
 #endif
 
+#ifndef SD_SPI_OVERCLOCK
+#define SD_SPI_OVERCLOCK 1
+#endif
+
 #ifndef USB_VENDOR_ID
 #define USB_VENDOR_ID 0xCafe
 #endif

--- a/32blit-pico/main.cpp
+++ b/32blit-pico/main.cpp
@@ -41,10 +41,6 @@ static void debug(const char *message) {
   usb_debug(message);
 }
 
-static bool is_storage_available() {
-  return true; // TODO: optional storage?
-}
-
 static uint32_t get_us_timer() {
   return to_us_since_boot(get_absolute_time());
 }

--- a/32blit-pico/storage.hpp
+++ b/32blit-pico/storage.hpp
@@ -3,6 +3,8 @@
 
 bool storage_init();
 
+bool is_storage_available();
+
 void get_storage_size(uint16_t &block_size, uint32_t &num_blocks);
 
 int32_t storage_read(uint32_t sector, uint32_t offset, void *buffer, uint32_t size_bytes);

--- a/32blit-pico/storage/flash.cpp
+++ b/32blit-pico/storage/flash.cpp
@@ -19,6 +19,10 @@ bool storage_init() {
   return true;
 }
 
+bool is_storage_available() {
+  return true;
+}
+
 void get_storage_size(uint16_t &block_size, uint32_t &num_blocks) {
   block_size = FLASH_SECTOR_SIZE;
   num_blocks = storage_size / FLASH_SECTOR_SIZE;

--- a/32blit-pico/storage/sd_spi.cpp
+++ b/32blit-pico/storage/sd_spi.cpp
@@ -405,6 +405,10 @@ bool storage_init() {
   return true;
 }
 
+bool is_storage_available() {
+  return card_size_blocks != 0;
+}
+
 void get_storage_size(uint16_t &block_size, uint32_t &num_blocks) {
   block_size = 512;
   num_blocks = card_size_blocks;

--- a/32blit-pico/storage/sd_spi.cpp
+++ b/32blit-pico/storage/sd_spi.cpp
@@ -37,18 +37,21 @@ static void spi_write(const uint8_t *buf, size_t len) {
 }
 
 static void spi_read(uint8_t *buf, size_t len) {
-  size_t tx_remain = len, rx_remain = len;
+  size_t rx_remain = len;
   auto txfifo = (io_rw_8 *) &sd_pio->txf[sd_sm];
   auto rxfifo = (io_rw_8 *) &sd_pio->rxf[sd_sm];
 
-  while (tx_remain || rx_remain) {
-    if (tx_remain && !pio_sm_is_tx_fifo_full(sd_pio, sd_sm)) {
-      *txfifo = 0xFF;
-      --tx_remain;
-    }
-    if (rx_remain && !pio_sm_is_rx_fifo_empty(sd_pio, sd_sm)) {
+  // assume FIFO is empty
+  *txfifo = 0xFF;
+  *txfifo = 0xFF;
+  *txfifo = 0xFF;
+  *txfifo = 0xFF;
+
+  while(rx_remain) {
+    if (!pio_sm_is_rx_fifo_empty(sd_pio, sd_sm)) {
       *buf++ = *rxfifo;
-      --rx_remain;
+      if(--rx_remain > 3)
+        *txfifo = 0xFF;
     }
   }
 }

--- a/32blit-pico/usb/device.cpp
+++ b/32blit-pico/usb/device.cpp
@@ -26,7 +26,7 @@ void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16
 }
 
 bool tud_msc_test_unit_ready_cb(uint8_t lun) {
-  if(storage_ejected) {
+  if(!is_storage_available() || storage_ejected ) {
     tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
     return false;
   }


### PR DESCRIPTION
First patch finally replaces the "storage available" stub with an actual implementation and doesn't claim there's storage if there's no card detected.

Second fixes the USB MSC code to report no medium if no card, which stops the host from polling repeatedly, causing timeouts reading the non-existent card and upsetting everything.

Third optimises block reads a bit, mostly because it ended up slightly too slow on RP2350 causing frequent read corruption. (That part should maybe be using DMA)

(Still need to update SD code to not assume clock is 125 or 250MHz, but it's currently working okay because we overclock everything to 250 still...)