### PR TITLE
Don't force 4-byte alignment on api structs

### DIFF
--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -149,7 +149,7 @@ namespace blit {
   };
 
   struct APIData {
-    uint16_t pad[2];
+    COMPAT_PAD(uint16_t, pad, 2);
 
     ButtonState buttons;
     float hack_left;

--- a/32blit/engine/api_private.hpp
+++ b/32blit/engine/api_private.hpp
@@ -68,7 +68,6 @@ namespace blit {
     IncompatibleBlit, /// file is incompatible with this device
   };
 
-  #pragma pack(push, 4)
   struct APIConst {
     uint16_t version_major;
     uint16_t version_minor;
@@ -176,8 +175,6 @@ namespace blit {
 
     COMPAT_PAD(uintptr_t, pad5, 5);
   };
-
-  #pragma pack(pop)
 
 #ifdef BLIT_API_SPLIT_COMPAT
   static_assert(sizeof(APIConst) == sizeof(APIData));


### PR DESCRIPTION
There aren't any 64-bit members in these structs so this should have no affect on 32-bit platforms and the packing is causing problems with misaligned pointers on (mac) arm64.

Should fix this error:
`ld: building fixups: pointer not aligned at __ZL14blit_api_const+0x4 from 32blit-sdl/libBlitHalSDL.a[10](System.cpp.o)`