### PR TITLE
CI: Switch to action-gh-release.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -195,22 +195,12 @@ jobs:
 
     - name: Upload tar
       if: github.event_name == 'release' && matrix.release-suffix != ''
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      uses: softprops/action-gh-release@v1
       with:
-        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz
-        upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}.tar.gz
-        asset_content_type: application/octet-stream #??
+        files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz
 
     - name: Upload zip
       if: github.event_name == 'release' && matrix.release-suffix != ''
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      uses: softprops/action-gh-release@v1
       with:
-        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
-        upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}.zip
-        asset_content_type: application/zip
+        files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip


### PR DESCRIPTION
Switch from the long deprecated upload-release-asset to action-gh-release and attempt to replicate the same behaviour.

Avoids nodejs and set-output deprecation warnings:
- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I've put this off for too long! `upload-release-asset` has been deprecated and unmaintained for years, causing a growing number of warnings in the Actions output.

Test release: https://github.com/32blit/32blit-sdk/releases/tag/TEST-DO-NOT-EAT