### PR TITLE
Make building for boards that don't have headers in the SDK easier

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
             name: PicoVision
             cache-key: picovision
             release-suffix: PicoVision
-            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pico_w -DPICO_ADDON=pimoroni_picovision -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pimoroni_picovision -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             apt-packages: ccache gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib pipx python3-requests
 
           - os: ubuntu-22.04

--- a/32blit-pico/CMakeLists.txt
+++ b/32blit-pico/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_policy(SET CMP0079 NEW) # target_link_libraries() allows use with targets 
 set(CMAKE_C_STANDARD 11)
 
 # Initialise the Pico SDK
+set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/board)
 include (pico_sdk_import.cmake)
 
 set(32BLIT_PICO 1 PARENT_SCOPE)

--- a/32blit-pico/board/pimoroni_picovision.h
+++ b/32blit-pico/board/pimoroni_picovision.h
@@ -1,0 +1,8 @@
+#ifndef _BOARDS_PIMORONI_PICOVISION_H
+#define _BOARDS_PIMORONI_PICOVISION_H
+
+#define PIMORONI_PICOVISION
+
+#include "boards/pico_w.h"
+
+#endif

--- a/32blit-pico/sdk_import.cmake
+++ b/32blit-pico/sdk_import.cmake
@@ -1,3 +1,4 @@
 if(PICO_BOARD)
+    set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/board)
     include(${CMAKE_CURRENT_LIST_DIR}/pico_sdk_import.cmake)
 endif()

--- a/docs/pico.md
+++ b/docs/pico.md
@@ -234,23 +234,22 @@ Additionally some supported features have limitations:
 
 The RP2040/Pico port supports PicoSystem, PicoVision and VGA board. Below is a table showing which features are available on each platform, and which `PICO_BOARD` to use to target them:
 
-|            | 32blit                       | PicoSystem                  | PicoVision               | VGA Board                
+|            | 32blit                       | PicoSystem                  | PicoVision               | VGA Board
 |------------|------------------------------|-----------------------------|--------------------------|--------------------------
-| PICO_BOARD | N/A                          | pimoroni_picosystem         | pico_w                   | vgaboard                 
-| PICO_ADDON | N/A                          | N/A                         | pimoroni_picovision      | N/A                      
-| CPU        | 480MHz                       | 250MHz †                    | 250MHz †                 | 250MHz †                 
-| RAM        | 583K §                       | 151K to 207K (lores only ¶) | ~250K                    | ~189K                    
-| FPU        | Yes                          | No                          | No                       | No                       
-| Buttons    | 6 + reset                    | 4 + power                   | HID Gamepad (up to 6)    | HID Gamepad (up to 6)    
-| Joystick   | Yes                          | No                          | HID Gamepad              | HID Gamepad              
-| Tilt       | Yes                          | No                          | No                       | No                       
-| Sound      | 8CH mini speaker             | 1CH piezo booper ‡          | 8CH 3.5mm jack (i2s DAC) | 8CH 3.5mm jack (i2s DAC) 
-| Storage    | 32MB XiP QSPI + 128K Flash   | 12MB XiP QSPI               | 2MB XiP QSPI             | 2MB XiP QSPI             
-|            | SD card for data             | 4MB QSPI for data (FAT)     | SD card for data         | SD card for data         
-| Screen     | 320x240 (160x120 lores)      | 240x240 (120x120 lores)     | 320x240 (160x120 lores)  | 160x120 only             
-| Firmware   | Yes                          | No                          | No                       | No                       
-| Launcher   | Browse + Launch Games        | No                          | No                       | No                       
-| LED        | Yes                          | Yes                         | No                       | No                       
+| PICO_BOARD | N/A                          | pimoroni_picosystem         | pimoroni_picovision      | vgaboard
+| CPU        | 480MHz                       | 250MHz †                    | 250MHz †                 | 250MHz †
+| RAM        | 583K §                       | 151K to 207K (lores only ¶) | ~250K                    | ~189K
+| FPU        | Yes                          | No                          | No                       | No
+| Buttons    | 6 + reset                    | 4 + power                   | HID Gamepad (up to 6)    | HID Gamepad (up to 6)
+| Joystick   | Yes                          | No                          | HID Gamepad              | HID Gamepad
+| Tilt       | Yes                          | No                          | No                       | No
+| Sound      | 8CH mini speaker             | 1CH piezo booper ‡          | 8CH 3.5mm jack (i2s DAC) | 8CH 3.5mm jack (i2s DAC)
+| Storage    | 32MB XiP QSPI + 128K Flash   | 12MB XiP QSPI               | 2MB XiP QSPI             | 2MB XiP QSPI
+|            | SD card for data             | 4MB QSPI for data (FAT)     | SD card for data         | SD card for data
+| Screen     | 320x240 (160x120 lores)      | 240x240 (120x120 lores)     | 320x240 (160x120 lores)  | 160x120 only
+| Firmware   | Yes                          | No                          | No                       | No
+| Launcher   | Browse + Launch Games        | No                          | No                       | No
+| LED        | Yes                          | Yes                         | No                       | No
 
 * † - technically 2 cores overclocked from 133MHz to 250MHz but the 32Blit SDK uses only one
 * ‡ - makes a best-effort attempt to play any `SQUARE` waveforms (single-channel)


### PR DESCRIPTION
Set the magic variable so we can have local board headers and add a minimal picovision header so we can do `-DPICO_BOARD=pimoroni_picovision` instead of `-DPICO_BOARD=pico_w -DPICO_ADDON=pimoroni_picovision`. This also makes the board metadata in the UF2 more useful.