### PR TITLE
sdl: fix installing on macos with sdl_image from homebrew

### DIFF
--- a/32blit-sdl/CMakeLists.txt
+++ b/32blit-sdl/CMakeLists.txt
@@ -193,7 +193,7 @@ function(blit_executable NAME)
 	endif()
 
 	if(APPLE)
-		set(SEARCH_DIRS /usr/local/lib)
+		set(SEARCH_DIRS /usr/local/lib /opt/homebrew/lib)
 
 		# assuming all frameworks installed in the same place
 		if(SDL2_FRAMEWORK_PATH)


### PR DESCRIPTION
Fixes this:
```
CMake Error at /opt/homebrew/Cellar/cmake/3.30.5/share/cmake/Modules/BundleUtilities.cmake:458 (message):
  otool -l failed: 1

  error:
  /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic:
  can't open file: @rpath/libjxl_cms.0.11.dylib (No such file or directory)

Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.30.5/share/cmake/Modules/BundleUtilities.cmake:527 (get_item_rpaths)
  /opt/homebrew/Cellar/cmake/3.30.5/share/cmake/Modules/BundleUtilities.cmake:649 (set_bundle_key_values)
  /opt/homebrew/Cellar/cmake/3.30.5/share/cmake/Modules/BundleUtilities.cmake:933 (get_bundle_keys)
  /Users/runner/work/super-blit-kart/main/build/fixup.cmake:3 (fixup_bundle)
  /Users/runner/work/super-blit-kart/main/build/cmake_install.cmake:51 (include)


CPack Error: Error when generating package: blit-kart
make: *** [package] Error 1
```
(Because we really need to bundle JPEG XL libraries...)