### PR TITLE
Specify a max version in cmake_minimum_required to remove some warnings

### DIFF
--- a/32blit-stm32/CMakeLists.txt
+++ b/32blit-stm32/CMakeLists.txt
@@ -1,3 +1,5 @@
+enable_language(ASM)
+
 add_subdirectory(../32blit-shared ../32blit-shared)
 
 add_library(BlitHalSTM32 OBJECT
@@ -107,8 +109,6 @@ add_library(BlitHalSTM32 OBJECT
 )
 
 set_source_files_properties(
-	startup_stm32h750xx.s
-
 	Src/main.c
   	Src/usbd_msc_scsi.c
 	Src/usb_device.c

--- a/32blit-stm32/executable.cmake
+++ b/32blit-stm32/executable.cmake
@@ -1,3 +1,5 @@
+enable_language(ASM)
+
 set(MCU_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/${MCU_LINKER_SCRIPT}")
 set(HAL_DIR ${CMAKE_CURRENT_LIST_DIR})
 
@@ -28,7 +30,6 @@ function(blit_executable NAME)
 		return()
 	endif()
 
-	set_source_files_properties(${USER_STARTUP} PROPERTIES LANGUAGE CXX)
 	add_executable(${NAME} ${USER_STARTUP} ${SOURCES})
 
 	# Ideally we want the .blit filename to match the .elf, but TARGET_FILE_BASE_NAME isn't always available

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.26)
 
 # has to be before project
 include(32blit-pico/sdk_import.cmake)

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.26)
 project (firmware)
 find_package (32BLIT CONFIG REQUIRED PATHS ..)
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.26)
 project (launcher)
 find_package (32BLIT CONFIG REQUIRED PATHS ..)
 

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.26)
 project (examples)
 find_package (32BLIT CONFIG REQUIRED PATHS ..)
 

--- a/utilities/hardware-test/CMakeLists.txt
+++ b/utilities/hardware-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.26)
 project (hardware-test)
 find_package (32BLIT CONFIG REQUIRED PATHS ../..)
 

--- a/utilities/picosystem-hardware-test/CMakeLists.txt
+++ b/utilities/picosystem-hardware-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.26)
 project (picosystem-hardware-test)
 find_package (32BLIT CONFIG REQUIRED PATHS ../..)
 


### PR DESCRIPTION
I'm getting a lot of `Compatibility with CMake < 3.10 will be removed from a future version of CMake.` warnings whenever I configure the examples. Specifying a maximum compatible version makes those go away. (CMake 3.27 removes `FindPythonInterp`, the replacement for that is `FindPython/FindPython3` but those require 3.12).

I also needed to fix how we compile asm files in 32blit-stm32 to be compatible with CMake 3.20, where setting the source `LANGUAGE` to CXX is interpreted as "compile as C++" not "use C++ compiler".


(We should maybe consider bumping the minimum version to clean some stuff up... I'm not sure how far back we're trying to support, but even Ubuntu 20.04 has 3.16 and Debian oldstable has 3.18)