### PR TITLE
docs: update required Debian version

### DIFF
--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -21,9 +21,9 @@ For local builds:
  - SDL2 + SDL2_image + SDL2_net
 
 For 32Blit device builds:
- - Arm Embedded GCC (`gcc-arm-none-eabi`, versions 8.x-12.x should work)
+ - Arm Embedded GCC (`gcc-arm-none-eabi`, versions 8.x-14.x should work)
 
-New enough versions of these exist in at least Debian "buster" and Ubuntu 20.04.
+New enough versions of these exist in at least Debian "bullseye" and Ubuntu 20.04.
 
 Install them with apt like so:
 


### PR DESCRIPTION
buster only has gcc-arm-none-eabi 7. Also bump the max as I'm currently using 14.

Technically already fixed, then broken again but... Fixes: #596