### PR TITLE
Remove -Werror=double-promotion

### DIFF
--- a/32blit.toolchain
+++ b/32blit.toolchain
@@ -20,7 +20,7 @@ endif ()
 
 set(CDC_FIFO_BUFFERS 64)
 
-set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -Werror=double-promotion -mno-pic-data-is-text-relative -mno-single-pic-base -DBLIT_API_SPLIT_COMPAT")
+set(COMMON_FLAGS "${MCU_FLAGS} -fsingle-precision-constant -Wall -fdata-sections -ffunction-sections -Wattributes -Wdouble-promotion -mno-pic-data-is-text-relative -mno-single-pic-base -DBLIT_API_SPLIT_COMPAT")
 
 set(CMAKE_C_FLAGS_INIT "${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS_INIT "${COMMON_FLAGS} -fno-exceptions")


### PR DESCRIPTION
This has been here ~forever because of "serious performance implications", but ends up causing a bunch of other issues. Like making it really annoying to print a float:
```
error: implicit conversion from 'float' to 'double' when passing argument to function [-Werror=double-promotion]
   32 |     snprintf(buf, sizeof(buf), "Accel\nX: %f\nY: %f\nZ: %f", accel_val.x, accel_val.y, accel_val.z);
      |                                                              ~~~~~~~~~~^

```

Also, I'm not sure how much `-fsingle-precision-constant` helps considering that it makes the behaviour different depending on what you're building for...
```c++
auto d = 1.0; // sometimes a float, sometimes a double!
```
