### PR TITLE
Add the other toolchains to the CMake kits list

### DIFF
--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,6 +1,14 @@
 [
-    {
-      "name": "32Blit",
-      "toolchainFile": "${workspaceFolder}/32blit.toolchain"
-    }
+  {
+    "name": "32Blit",
+    "toolchainFile": "${workspaceFolder}/32blit.toolchain"
+  },
+  {
+    "name": "32Blit-Pico",
+    "toolchainFile": "${workspaceFolder}/pico.toolchain"
+  },
+  {
+    "name": "32Blit-Pico2",
+    "toolchainFile": "${workspaceFolder}/pico2.toolchain"
+  }
 ]


### PR DESCRIPTION
For consistency. Also makes it easier to check if your setup works. (Would need to add these to the global list to build anything other than the SDK/examples)