### PR TITLE
Fix Windows SDL2 + CMake 4 brokenness

### DIFF
--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Checkout Examples
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: 32blit/32blit-examples
         path: 32blit-examples
@@ -34,7 +34,7 @@ jobs:
 
     - name: Setup cache
       id: cache-system-libraries
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{env.EM_CACHE_FOLDER}}
         key: ${{env.EM_VERSION}}-${{runner.os}}
@@ -74,7 +74,7 @@ jobs:
         cp ../build/*/*.{js,wasm} site/examples
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{github.event.repository.name}}-${{github.sha}}-web
         path: site

--- a/.github/workflows/Visual Studio.yml
+++ b/.github/workflows/Visual Studio.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Checkout Examples
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: 32blit/32blit-examples
         path: examples

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -90,10 +90,10 @@ jobs:
 
     steps:
     - name: Checkout 32Blit SDK
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Checkout Examples
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: 32blit/32blit-examples
         path: examples
@@ -101,7 +101,7 @@ jobs:
     # pico sdk/extras for some builds
     - name: Checkout Pico SDK
       if: matrix.pico-sdk
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: raspberrypi/pico-sdk
         path: pico-sdk
@@ -109,7 +109,7 @@ jobs:
 
     - name: Checkout Pico Extras
       if: matrix.pico-sdk
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: raspberrypi/pico-extras
         path: pico-extras
@@ -117,14 +117,14 @@ jobs:
     # PicoVision needs the RAM driver and the firmware
     - name: Checkout PicoVision
       if: matrix.name == 'PicoVision'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: pimoroni/picovision
         ref: 03df7694ed4fb396c1d12adf90d0150ada6baedc
         path: picovision
 
     - name: Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.ccache
@@ -207,7 +207,7 @@ jobs:
 
     - name: Upload Artifact
       if: github.event_name != 'release'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{env.RELEASE_FILE}}
         path: ${{runner.workspace}}/build/install

--- a/ci/install_sdl_macos.sh
+++ b/ci/install_sdl_macos.sh
@@ -1,5 +1,5 @@
 if [ ! -f ~/Library/Frameworks/SDL2_net.framework/SDL2_net ]; then
-    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-2.24.0.dmg -o SDL2.dmg
+    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.dmg -o SDL2.dmg
     curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-2.6.2.dmg -o SDL2_image.dmg
     curl -L https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-2.2.0.dmg -o SDL2_net.dmg
 

--- a/ci/install_sdl_mingw.sh
+++ b/ci/install_sdl_mingw.sh
@@ -1,6 +1,6 @@
 if [ ! -f SDL2_net/README.txt ]; then
-    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-mingw.tar.gz -o SDL2.tar.gz
-    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-devel-2.6.2-mingw.tar.gz -o SDL2_image.tar.gz
+    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-devel-2.28.5-mingw.tar.gz -o SDL2.tar.gz
+    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.12/SDL2_image-devel-2.8.12-mingw.tar.gz -o SDL2_image.tar.gz
     curl -L https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-mingw.tar.gz -o SDL2_net.tar.gz
 
     tar -xf SDL2.tar.gz
@@ -8,7 +8,7 @@ if [ ! -f SDL2_net/README.txt ]; then
     tar -xf SDL2_net.tar.gz
 
     # remove the version
-    mv SDL2-2.24.0 SDL2
-    mv SDL2_image-2.6.2 SDL2_image
+    mv SDL2-2.28.5 SDL2
+    mv SDL2_image-2.8.12 SDL2_image
     mv SDL2_net-2.2.0 SDL2_net
 fi

--- a/ci/install_sdl_vs.sh
+++ b/ci/install_sdl_vs.sh
@@ -1,6 +1,6 @@
 if [ ! -f vs/sdl/include/SDL_net.h ]; then
-    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.24.0/SDL2-devel-2.24.0-VC.zip -o SDL2.zip
-    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-devel-2.6.2-VC.zip -o SDL2_image.zip
+    curl -L https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-devel-2.28.5-VC.zip -o SDL2.zip
+    curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.12/SDL2_image-devel-2.8.12-VC.zip -o SDL2_image.zip
     curl -L https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-VC.zip -o SDL2_net.zip
 
     unzip SDL2.zip -d vs/sdl
@@ -8,7 +8,7 @@ if [ ! -f vs/sdl/include/SDL_net.h ]; then
     unzip -o SDL2_net.zip -d vs/sdl
 
     # move dirs up
-    mv vs/sdl/SDL2-2.24.0/* vs/sdl
-    cp -r vs/sdl/SDL2_image-2.6.2/* vs/sdl
+    mv vs/sdl/SDL2-2.28.5/* vs/sdl
+    cp -r vs/sdl/SDL2_image-2.8.12/* vs/sdl
     cp -r vs/sdl/SDL2_net-2.2.0/* vs/sdl
 fi

--- a/vs/sdl/sdl2-config.cmake
+++ b/vs/sdl/sdl2-config.cmake
@@ -19,8 +19,8 @@ function(fetch_sdl2_library directory url filename hash)
     endif()
 endfunction(fetch_sdl2_library)
 
-set(SDL2_VERSION 2.24.0)
-set(SDL2_IMAGE_VERSION 2.6.2)
+set(SDL2_VERSION 2.28.5)
+set(SDL2_IMAGE_VERSION 2.8.12)
 set(SDL2_NET_VERSION 2.2.0)
 
 if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -29,14 +29,14 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include)
         SDL2-${SDL2_VERSION}
         https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/
         SDL2-devel-${SDL2_VERSION}-VC.zip
-        8a54459189e88c30ba024ee5f18ce4b1a5d1d9e7
+        7469e9ea44d30a48b0510328cd94b25596e0aa0f
     )
 
     fetch_sdl2_library(
         SDL2_image-${SDL2_IMAGE_VERSION}
         https://github.com/libsdl-org/SDL_image/releases/download/release-${SDL2_IMAGE_VERSION}/
         SDL2_image-devel-${SDL2_IMAGE_VERSION}-VC.zip
-        4111affcca1f4b41c2f4b4c445ccf06fe081b5e9
+        fbb2bff20c616949b1dc2fc35bad0ec55cf9d9f8
     )
 
     fetch_sdl2_library(
@@ -54,3 +54,6 @@ get_property(SDL2_DLL TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION)
 # help cmake to find the other libs
 set(SDL2_image_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_image-${SDL2_IMAGE_VERSION}/cmake)
 set(SDL2_net_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2_net-${SDL2_NET_VERSION}/cmake)
+
+# the latest SDL2_net (2.4.0) still has cmake_minimum_required(VERSION 3.0) in its config file for VC
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)


### PR DESCRIPTION
```
Compatibility with CMake < 3.5 has been removed from CMake.
```
Strikes again...

Tried to keep this to the minimum updating to fix things (and not break other things, which updating SDL2_image on macOS would do...)

(I was trying to test the upload-artifact action [finally supporting not zipping a file](https://github.com/actions/upload-artifact#upload-an-individual-file-unzipped), but got windows breakage instead...)